### PR TITLE
Hyperlinks

### DIFF
--- a/src/us/deathmarine/luyten/ConfigSaver.java
+++ b/src/us/deathmarine/luyten/ConfigSaver.java
@@ -32,7 +32,6 @@ public class ConfigSaver {
 	private WindowPosition mainWindowPosition;
 	private WindowPosition findWindowPosition;
 	private LuytenPreferences luytenPreferences;
-	private boolean isUnicodeReplaceEnabled;
 
 	private static ConfigSaver theLoadedInstance;
 
@@ -86,7 +85,7 @@ public class ConfigSaver {
 					decompilerSettings.getIncludeErrorDiagnostics()));
 			decompilerSettings.setLanguage(findLanguageByName(prefs.get(LANGUAGE_NAME_ID,
 					decompilerSettings.getLanguage().getName())));
-			isUnicodeReplaceEnabled = prefs.getBoolean(UNICODE_REPLACE_ENABLED_ID, false);
+			decompilerSettings.setUnicodeOutputEnabled(prefs.getBoolean(UNICODE_REPLACE_ENABLED_ID, false));
 
 			mainWindowPosition = loadWindowPosition(prefs, MAIN_WINDOW_ID_PREFIX);
 			findWindowPosition = loadWindowPosition(prefs, FIND_WINDOW_ID_PREFIX);
@@ -134,7 +133,7 @@ public class ConfigSaver {
 
 	public void saveConfig() {
 		// Registry path on Windows Xp:
-		// HKEY_CURRENT_USER\Software\JavaSoft\Prefs\com\modcrafting\luyten
+		// HKEY_CURRENT_USER/Software/JavaSoft/Prefs/us/deathmarine/luyten
 		try {
 			Preferences prefs = Preferences.userNodeForPackage(ConfigSaver.class);
 
@@ -145,7 +144,7 @@ public class ConfigSaver {
 			prefs.putBoolean(FORCE_EXPLICIT_TYPE_ARGUMENTS_ID, decompilerSettings.getForceExplicitTypeArguments());
 			prefs.putBoolean(RETAIN_REDUNDANT_CASTS_ID, decompilerSettings.getRetainRedundantCasts());
 			prefs.putBoolean(INCLUDE_ERROR_DIAGNOSTICS_ID, decompilerSettings.getIncludeErrorDiagnostics());
-			prefs.putBoolean(UNICODE_REPLACE_ENABLED_ID, isUnicodeReplaceEnabled);
+			prefs.putBoolean(UNICODE_REPLACE_ENABLED_ID, decompilerSettings.isUnicodeOutputEnabled());
 			prefs.put(LANGUAGE_NAME_ID, decompilerSettings.getLanguage().getName());
 
 			saveWindowPosition(prefs, MAIN_WINDOW_ID_PREFIX, mainWindowPosition);
@@ -207,14 +206,6 @@ public class ConfigSaver {
 
 	public DecompilerSettings getDecompilerSettings() {
 		return decompilerSettings;
-	}
-
-	public boolean isUnicodeReplaceEnabled(){
-		return isUnicodeReplaceEnabled;
-	}
-
-	public void setUnicodeReplaceEnabled(boolean value){
-		isUnicodeReplaceEnabled = value;
 	}
 
 	public WindowPosition getMainWindowPosition() {

--- a/src/us/deathmarine/luyten/DecompilerLinkProvider.java
+++ b/src/us/deathmarine/luyten/DecompilerLinkProvider.java
@@ -1,0 +1,383 @@
+package us.deathmarine.luyten;
+
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import com.strobel.assembler.metadata.FieldDefinition;
+import com.strobel.assembler.metadata.FieldReference;
+import com.strobel.assembler.metadata.MetadataSystem;
+import com.strobel.assembler.metadata.MethodDefinition;
+import com.strobel.assembler.metadata.MethodReference;
+import com.strobel.assembler.metadata.TypeDefinition;
+import com.strobel.assembler.metadata.TypeReference;
+import com.strobel.core.StringUtilities;
+import com.strobel.decompiler.DecompilationOptions;
+import com.strobel.decompiler.DecompilerSettings;
+import com.strobel.decompiler.PlainTextOutput;
+
+public class DecompilerLinkProvider implements LinkProvider {
+
+	private Map<String, Selection> definitionToSelectionMap = new HashMap<>();
+	private Map<String, Set<Selection>> referenceToSelectionsMap = new HashMap<>();
+	private boolean isSelectionMapsPopulated = false;
+
+	private MetadataSystem metadataSystem;
+	private DecompilerSettings settings;
+	private DecompilationOptions decompilationOptions;
+	private TypeDefinition type;
+
+	private String currentTypeQualifiedName;
+	private String textContent = "";
+
+	@Override
+	public void generateContent() {
+		definitionToSelectionMap = new HashMap<>();
+		referenceToSelectionsMap = new HashMap<>();
+		currentTypeQualifiedName = type.getPackageName() + "." + type.getName();
+		final StringWriter stringwriter = new StringWriter();
+		settings.getLanguage().decompileType(type, new PlainTextOutput(stringwriter) {
+			@Override
+			public void writeDefinition(String text, Object definition, boolean isLocal) {
+				super.writeDefinition(text, definition, isLocal);
+				try {
+					if (text != null && definition != null) {
+						String uniqueStr = createUniqueStrForReference(definition);
+						if (uniqueStr != null) {
+							// fix link's underline length: _java.util.HashSet_ -> _HashSet_
+							text = text.replaceAll("[^\\.]*\\.", "");
+							int from = stringwriter.getBuffer().length() - text.length();
+							int to = stringwriter.getBuffer().length();
+							definitionToSelectionMap.put(uniqueStr, new Selection(from, to));
+						}
+					}
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+
+			@Override
+			public void writeReference(String text, Object reference, boolean isLocal) {
+				super.writeReference(text, reference, isLocal);
+				try {
+					if (text != null && reference != null) {
+						String uniqueStr = createUniqueStrForReference(reference);
+						if (uniqueStr != null) {
+							text = text.replaceAll("[^\\.]*\\.", "");
+							int from = stringwriter.getBuffer().length() - text.length();
+							int to = stringwriter.getBuffer().length();
+							if (reference instanceof FieldReference) {
+								// fix enum definition links (note: could not fix enum reference links)
+								if (((FieldReference) reference).isDefinition()) {
+									definitionToSelectionMap.put(uniqueStr, new Selection(from, to));
+									return;
+								}
+							}
+							if (referenceToSelectionsMap.containsKey(uniqueStr)) {
+								Set<Selection> selectionsSet = referenceToSelectionsMap.get(uniqueStr);
+								if (selectionsSet != null) {
+									selectionsSet.add(new Selection(from, to));
+								}
+							} else {
+								Set<Selection> selectionsSet = new HashSet<>();
+								selectionsSet.add(new Selection(from, to));
+								referenceToSelectionsMap.put(uniqueStr, selectionsSet);
+							}
+						}
+					}
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		}, decompilationOptions);
+		textContent = stringwriter.toString();
+		isSelectionMapsPopulated = true;
+	}
+
+	private String createUniqueStrForReference(Object reference) {
+		String uniqueStr = null;
+		if (reference instanceof TypeReference) {
+			TypeReference type = (TypeReference) reference;
+			String pathAndTypeStr = getPathAndTypeStr(type);
+			if (pathAndTypeStr != null) {
+				uniqueStr = "type|" + pathAndTypeStr;
+			}
+		} else if (reference instanceof MethodReference) {
+			MethodReference method = (MethodReference) reference;
+			String pathAndTypeStr = getPathAndTypeStr(method.getDeclaringType());
+			if (pathAndTypeStr != null) {
+				uniqueStr = "method|" + pathAndTypeStr + "|" +
+						method.getName() + "|" + method.getErasedSignature();
+			}
+		} else if (reference instanceof FieldReference) {
+			FieldReference field = (FieldReference) reference;
+			String pathAndTypeStr = getPathAndTypeStr(field.getDeclaringType());
+			if (pathAndTypeStr != null) {
+				uniqueStr = "field|" + pathAndTypeStr + "|" + field.getName();
+			}
+		}
+		return uniqueStr;
+	}
+
+	private String getPathAndTypeStr(TypeReference typeRef) {
+		String name = typeRef.getName();
+		String packageStr = typeRef.getPackageName();
+		TypeReference mostOuterTypeRef = getMostOuterTypeRef(typeRef);
+		String mostOuterTypeName = mostOuterTypeRef.getName();
+		if (name != null && packageStr != null && mostOuterTypeName != null &&
+				name.trim().length() > 0 && mostOuterTypeName.trim().length() > 0) {
+			String pathStr = packageStr.replaceAll("\\.", "/") + "/" + mostOuterTypeName;
+			String typeStr = packageStr + "." + name.replace(".", "$");
+			return pathStr + "|" + typeStr;
+		}
+		return null;
+	}
+
+	private TypeReference getMostOuterTypeRef(TypeReference typeRef) {
+		int maxDecraringDepth = typeRef.getFullName().split("(\\.|\\$)").length;
+		for (int i = 0; i < maxDecraringDepth; i++) {
+			TypeReference declaringTypeRef = typeRef.getDeclaringType();
+			if (declaringTypeRef == null) {
+				break;
+			} else {
+				typeRef = declaringTypeRef;
+			}
+		}
+		if (typeRef.getName().contains("$")) {
+			return getMostOuterTypeRefBySlowLookuping(typeRef);
+		}
+		return typeRef;
+	}
+
+	private TypeReference getMostOuterTypeRefBySlowLookuping(TypeReference typeRef) {
+		String name = typeRef.getName();
+		if (name == null)
+			return typeRef;
+		String packageName = typeRef.getPackageName();
+		if (packageName == null)
+			return typeRef;
+		String[] nameParts = name.split("\\$");
+		String newName = "";
+		String sep = "";
+		for (int i = 0; i < nameParts.length - 1; i++) {
+			newName = newName + sep + nameParts[i];
+			sep = "$";
+			String newInternalName = packageName.replaceAll("\\.", "/") + "/" + newName;
+			TypeReference newTypeRef = metadataSystem.lookupType(newInternalName);
+			if (newTypeRef != null) {
+				TypeDefinition newTypeDef = newTypeRef.resolve();
+				if (newTypeDef != null) {
+					return newTypeRef;
+				}
+			}
+		}
+		return typeRef;
+	}
+
+	@Override
+	public String getTextContent() {
+		return textContent;
+	}
+
+	@Override
+	public void processLinks() {}
+
+	@Override
+	public Map<String, Selection> getDefinitionToSelectionMap() {
+		return definitionToSelectionMap;
+	}
+
+	@Override
+	public Map<String, Set<Selection>> getReferenceToSelectionsMap() {
+		return referenceToSelectionsMap;
+	}
+
+	@Override
+	public boolean isLinkNavigable(String uniqueStr) {
+		if (isSelectionMapsPopulated && definitionToSelectionMap.containsKey(uniqueStr))
+			return true;
+		if (uniqueStr == null)
+			return false;
+		String[] linkParts = uniqueStr.split("\\|");
+		if (linkParts.length < 3)
+			return false;
+		String typeStr = linkParts[2];
+		if (typeStr.trim().length() <= 0)
+			return false;
+		TypeReference typeRef = metadataSystem.lookupType(typeStr.replaceAll("\\.", "/"));
+		if (typeRef == null)
+			return false;
+		TypeDefinition typeDef = typeRef.resolve();
+		if (typeDef == null)
+			return false;
+		if (typeDef.isSynthetic())
+			return false;
+
+		if (isSelectionMapsPopulated) {
+			// current type's navigable definitions checked already, now it's erroneous
+			if (currentTypeQualifiedName == null || currentTypeQualifiedName.trim().length() <= 0)
+				return false;
+			if (typeStr.equals(currentTypeQualifiedName) ||
+					typeStr.startsWith(currentTypeQualifiedName + ".") ||
+					typeStr.startsWith(currentTypeQualifiedName + "$"))
+				return false;
+		}
+
+		// check linked field/method exists
+		if (uniqueStr.startsWith("method")) {
+			if (findMethodInType(typeDef, uniqueStr) == null) {
+				return false;
+			}
+		} else if (uniqueStr.startsWith("field")) {
+			if (findFieldInType(typeDef, uniqueStr) == null) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private MethodDefinition findMethodInType(TypeDefinition typeDef, String uniqueStr) {
+		String[] linkParts = uniqueStr.split("\\|");
+		if (linkParts.length != 5)
+			return null;
+		String methodName = linkParts[3];
+		String methodErasedSignature = linkParts[4];
+		if (methodName.trim().length() <= 0 || methodErasedSignature.trim().length() <= 0)
+			return null;
+		List<MethodDefinition> declaredMethods = typeDef.getDeclaredMethods();
+		if (declaredMethods == null)
+			return null;
+		boolean isFound = false;
+		for (MethodDefinition declaredMethod : declaredMethods) {
+			isFound = (declaredMethod != null && methodName.equals(declaredMethod.getName()));
+			isFound = (isFound && methodErasedSignature.equals(declaredMethod.getErasedSignature()));
+			if (isFound) {
+				if (declaredMethod.isSynthetic() && !settings.getShowSyntheticMembers()) {
+					return null;
+				} else {
+					return declaredMethod;
+				}
+			}
+		}
+		return null;
+	}
+
+	private FieldDefinition findFieldInType(TypeDefinition typeDef, String uniqueStr) {
+		String[] linkParts = uniqueStr.split("\\|");
+		if (linkParts.length != 4)
+			return null;
+		String fieldName = linkParts[3];
+		if (fieldName.trim().length() <= 0)
+			return null;
+		List<FieldDefinition> declaredFields = typeDef.getDeclaredFields();
+		if (declaredFields == null)
+			return null;
+		boolean isFound = false;
+		for (FieldDefinition declaredField : declaredFields) {
+			isFound = (declaredField != null && fieldName.equals(declaredField.getName()));
+			if (isFound) {
+				if (declaredField.isSynthetic()) {
+					return null;
+				} else {
+					return declaredField;
+				}
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public String getLinkDescription(String uniqueStr) {
+		String readableLink = null;
+		try {
+			if (uniqueStr == null)
+				return null;
+			String[] linkParts = uniqueStr.split("\\|");
+			if (linkParts.length < 3)
+				return null;
+			String typeStr = linkParts[2];
+			TypeReference typeRef = metadataSystem.lookupType(typeStr.replaceAll("\\.", "/"));
+			if (typeRef == null)
+				return null;
+			TypeDefinition typeDef = typeRef.resolve();
+			if (typeDef == null)
+				return null;
+
+			String declaredSuffix = "";
+			String mostOuterTypeStr = linkParts[1].replaceAll("/", ".");
+			boolean isOwnFile = mostOuterTypeStr.equals(currentTypeQualifiedName);
+			if (!isOwnFile) {
+				declaredSuffix = " - Declared: " + mostOuterTypeStr;
+			}
+
+			if (uniqueStr.startsWith("type")) {
+				String desc = typeDef.getBriefDescription();
+				if (desc != null && desc.trim().length() > 0) {
+					readableLink = desc;
+				}
+			} else if (uniqueStr.startsWith("method")) {
+				MethodDefinition methodDef = findMethodInType(typeDef, uniqueStr);
+				if (methodDef == null)
+					return null;
+				String desc = methodDef.getBriefDescription();
+				if (desc != null && desc.trim().length() > 0) {
+
+					if (desc.contains("void <init>")) {
+						String constructorName = typeDef.getName();
+						TypeReference declaringTypeRef = typeRef.getDeclaringType();
+						if (declaringTypeRef != null) {
+							TypeDefinition declaringTypeDef = declaringTypeRef.resolve();
+							if (declaringTypeDef != null) {
+								String declaringTypeName = declaringTypeDef.getName();
+								if (declaringTypeName != null) {
+									constructorName = StringUtilities.removeLeft(constructorName, declaringTypeName);
+									constructorName = constructorName.replaceAll("^(\\.|\\$)", "");
+								}
+							}
+						}
+						desc = desc.replace("void <init>", constructorName);
+						readableLink = "Constructor: " + erasePackageInfoFromDesc(desc) + declaredSuffix;
+					} else {
+						readableLink = erasePackageInfoFromDesc(desc) + declaredSuffix;
+					}
+				}
+			} else if (uniqueStr.startsWith("field")) {
+				FieldDefinition fieldDef = findFieldInType(typeDef, uniqueStr);
+				if (fieldDef == null)
+					return null;
+				String desc = fieldDef.getBriefDescription();
+				if (desc != null && desc.trim().length() > 0) {
+					readableLink = erasePackageInfoFromDesc(desc) + declaredSuffix;
+				}
+
+			}
+			if (readableLink != null) {
+				readableLink = readableLink.replace("$", ".");
+			}
+		} catch (Exception e) {
+			readableLink = null;
+			e.printStackTrace();
+		}
+		return readableLink;
+	}
+
+	private String erasePackageInfoFromDesc(String desc) {
+		String limiters = "\\(\\)\\<\\>\\[\\]\\?\\s,";
+		desc = desc.replaceAll("(?<=[^" + limiters + "]*)([^" + limiters + "]*)\\.", "");
+		return desc;
+	}
+
+	public void setDecompilerReferences(MetadataSystem metadataSystem,
+			DecompilerSettings settings,
+			DecompilationOptions decompilationOptions) {
+		this.metadataSystem = metadataSystem;
+		this.settings = settings;
+		this.decompilationOptions = decompilationOptions;
+	}
+
+	public void setType(TypeDefinition type) {
+		this.type = type;
+	}
+}

--- a/src/us/deathmarine/luyten/DecompilerLinkProvider.java
+++ b/src/us/deathmarine/luyten/DecompilerLinkProvider.java
@@ -38,7 +38,7 @@ public class DecompilerLinkProvider implements LinkProvider {
 		referenceToSelectionsMap = new HashMap<>();
 		currentTypeQualifiedName = type.getPackageName() + "." + type.getName();
 		final StringWriter stringwriter = new StringWriter();
-		settings.getLanguage().decompileType(type, new PlainTextOutput(stringwriter) {
+		PlainTextOutput plainTextOutput = new PlainTextOutput(stringwriter) {
 			@Override
 			public void writeDefinition(String text, Object definition, boolean isLocal) {
 				super.writeDefinition(text, definition, isLocal);
@@ -91,7 +91,9 @@ public class DecompilerLinkProvider implements LinkProvider {
 					e.printStackTrace();
 				}
 			}
-		}, decompilationOptions);
+		};
+		plainTextOutput.setUnicodeOutputEnabled(decompilationOptions.getSettings().isUnicodeOutputEnabled());
+		settings.getLanguage().decompileType(type, plainTextOutput, decompilationOptions);
 		textContent = stringwriter.toString();
 		isSelectionMapsPopulated = true;
 	}

--- a/src/us/deathmarine/luyten/FileDialog.java
+++ b/src/us/deathmarine/luyten/FileDialog.java
@@ -23,9 +23,15 @@ public class FileDialog {
 
 		new Thread() {
 			public void run() {
-				initOpenDialog();
-				initSaveDialog();
-				initSaveAllDialog();
+				try {
+					initOpenDialog();
+					Thread.sleep(500);
+					initSaveAllDialog();
+					Thread.sleep(500);
+					initSaveDialog();
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
 			};
 		}.start();
 	}
@@ -62,7 +68,7 @@ public class FileDialog {
 	public File doSaveAllDialog(String recommendedFileName) {
 		File selectedFile = null;
 		initSaveAllDialog();
-		
+
 		retrieveSaveDialogDir(fcSaveAll);
 		fcSaveAll.setSelectedFile(new File(recommendedFileName));
 		int returnVal = fcSaveAll.showSaveDialog(parent);

--- a/src/us/deathmarine/luyten/FindAllBox.java
+++ b/src/us/deathmarine/luyten/FindAllBox.java
@@ -163,9 +163,14 @@ public class FindAllBox extends JDialog {
 									decompilationOptions.setSettings(settings);
 									decompilationOptions
 											.setFullDecompilation(true);
+									PlainTextOutput plainTextOutput = 
+											new PlainTextOutput(stringwriter);
+									plainTextOutput.setUnicodeOutputEnabled(
+											decompilationOptions.getSettings()
+											.isUnicodeOutputEnabled());
 									settings.getLanguage().decompileType(
 											resolvedType,
-											new PlainTextOutput(stringwriter),
+											plainTextOutput,
 											decompilationOptions);
 									String decompiledSource = stringwriter
 											.toString().toLowerCase();

--- a/src/us/deathmarine/luyten/FindBox.java
+++ b/src/us/deathmarine/luyten/FindBox.java
@@ -37,6 +37,7 @@ public class FindBox extends JDialog {
 	public void showFindBox() {
 		this.setVisible(true);
 		this.textField.requestFocus();
+		this.textField.selectAll();
 	}
 
 	public void hideFindBox() {

--- a/src/us/deathmarine/luyten/LinkProvider.java
+++ b/src/us/deathmarine/luyten/LinkProvider.java
@@ -1,0 +1,17 @@
+package us.deathmarine.luyten;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface LinkProvider {
+
+	public void generateContent();
+	public String getTextContent();
+	public void processLinks();
+
+	public Map<String, Selection> getDefinitionToSelectionMap();
+	public Map<String, Set<Selection>> getReferenceToSelectionsMap();
+	public boolean isLinkNavigable(String uniqueStr);
+	public String getLinkDescription(String uniqueStr);
+
+}

--- a/src/us/deathmarine/luyten/MainMenuBar.java
+++ b/src/us/deathmarine/luyten/MainMenuBar.java
@@ -362,7 +362,7 @@ public class MainMenuBar extends JMenuBar {
 		settingsMenu.add(retainRedundantCasts);
 
 		unicodeReplacement = new JCheckBox("    Enable Unicode Replacement");
-		unicodeReplacement.setSelected(configSaver.isUnicodeReplaceEnabled());
+		unicodeReplacement.setSelected(settings.isUnicodeOutputEnabled());
 		unicodeReplacement.setContentAreaFilled(false);
 		unicodeReplacement.setFocusable(false);
 		unicodeReplacement.addActionListener(settingsChanged);
@@ -452,7 +452,7 @@ public class MainMenuBar extends JMenuBar {
 			settings.setForceExplicitTypeArguments(forceExplicitTypes.isSelected());
 			settings.setRetainRedundantCasts(retainRedundantCasts.isSelected());
 			settings.setIncludeErrorDiagnostics(showDebugInfo.isSelected());
-			ConfigSaver.getLoadedInstance().setUnicodeReplaceEnabled(unicodeReplacement.isSelected());
+			settings.setUnicodeOutputEnabled(unicodeReplacement.isSelected());
 			//
 			// Note: You shouldn't ever need to set this.  It's only for languages that support catch
 			//       blocks without an exception variable.  Java doesn't allow this.  I think Scala does.

--- a/src/us/deathmarine/luyten/MainWindow.java
+++ b/src/us/deathmarine/luyten/MainWindow.java
@@ -291,6 +291,10 @@ public class MainWindow extends JFrame {
 		}
 	}
 
+	public void onNavigationRequest(String uniqueStr) {
+		this.getModel().navigateTo(uniqueStr);
+	}
+
 	private void adjustWindowPositionBySavedState() {
 		Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
 		if (!windowPosition.isSavedWindowPositionValid()) {

--- a/src/us/deathmarine/luyten/Model.java
+++ b/src/us/deathmarine/luyten/Model.java
@@ -25,8 +25,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
@@ -143,24 +141,35 @@ public class Model extends JSplitPane {
 	}
 
 	public void showLegal(String legalStr) {
-		OpenFile open = new OpenFile("Legal", "*/Legal", legalStr, theme);
+		OpenFile open = new OpenFile("Legal", "*/Legal", theme, mainWindow);
+		open.setContent(legalStr);
 		hmap.add(open);
 		addOrSwitchToTab(open);
 	}
 
-	private void addOrSwitchToTab(OpenFile open) {
-		String title = open.name;
-		RTextScrollPane rTextScrollPane = open.scrollPane;
-		if (house.indexOfTab(title) < 0) {
-			house.addTab(title, rTextScrollPane);
-			house.setSelectedIndex(house.indexOfTab(title));
-			int index = house.indexOfTab(title);
-			Tab ct = new Tab(title);
-			ct.getButton().addMouseListener(new CloseTab(title));
-			house.setTabComponentAt(index, ct);
-		} else {
-			house.setSelectedIndex(house.indexOfTab(title));
-		}
+	private void addOrSwitchToTab(final OpenFile open) {
+		SwingUtilities.invokeLater(new Runnable() {
+			@Override
+			public void run() {
+				try {
+					String title = open.name;
+					RTextScrollPane rTextScrollPane = open.scrollPane;
+					if (house.indexOfTab(title) < 0) {
+						house.addTab(title, rTextScrollPane);
+						house.setSelectedIndex(house.indexOfTab(title));
+						int index = house.indexOfTab(title);
+						Tab ct = new Tab(title);
+						ct.getButton().addMouseListener(new CloseTab(title));
+						house.setTabComponentAt(index, ct);
+					} else {
+						house.setSelectedIndex(house.indexOfTab(title));
+					}
+					open.onAddedToScreen();
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		});
 	}
 
 	private void closeOpenTab(int index) {
@@ -173,6 +182,8 @@ public class Model extends JSplitPane {
 		if (open != null && hmap.contains(open))
 			hmap.remove(open);
 		house.remove(co);
+		if (open != null)
+			open.close();
 	}
 
 	private String getName(String path) {
@@ -252,7 +263,7 @@ public class Model extends JSplitPane {
 						label.setText("Extracting: " + name);
 						String internalName = StringUtilities.removeRight(entryName, ".class");
 						TypeReference type = metadataSystem.lookupType(internalName);
-						extractClassToTextPane(type, name, path);
+						extractClassToTextPane(type, name, path, null);
 					} else {
 						label.setText("Opening: " + name);
 						try (InputStream in = state.jarFile.getInputStream(entry);) {
@@ -269,7 +280,7 @@ public class Model extends JSplitPane {
 				if (name.endsWith(".class")) {
 					label.setText("Extracting: " + name);
 					TypeReference type = metadataSystem.lookupType(path);
-					extractClassToTextPane(type, name, path);
+					extractClassToTextPane(type, name, path, null);
 				} else {
 					label.setText("Opening: " + name);
 					try (InputStream in = new FileInputStream(file);) {
@@ -293,7 +304,8 @@ public class Model extends JSplitPane {
 		}
 	}
 
-	private void extractClassToTextPane(TypeReference type, String tabTitle, String path) throws Exception {
+	private void extractClassToTextPane(TypeReference type, String tabTitle, String path,
+			String navigatonLink) throws Exception {
 		if (tabTitle == null || tabTitle.trim().length() < 1 || path == null) {
 			throw new FileEntryNotFoundException();
 		}
@@ -304,54 +316,37 @@ public class Model extends JSplitPane {
 				break;
 			}
 		}
-		if (sameTitledOpen != null && path.equals(sameTitledOpen.getPath()) &&
+		if (sameTitledOpen != null && path.equals(sameTitledOpen.path) &&
 				type.equals(sameTitledOpen.getType()) && sameTitledOpen.isContentValid()) {
+			sameTitledOpen.setInitialNavigationLink(navigatonLink);
 			addOrSwitchToTab(sameTitledOpen);
 			return;
 		}
 
-		// build tab content: do decompilation
-		String decompiledSource = extractClassToString(type);
+		// resolve TypeDefinition
+		TypeDefinition resolvedType = null;
+		if (type == null || ((resolvedType = type.resolve()) == null)) {
+			throw new Exception("Unable to resolve type.");
+		}
 
-		// open tab, store type information
+		// open tab, store type information, start decompilation
 		if (sameTitledOpen != null) {
-			sameTitledOpen.setContent(decompiledSource);
-			sameTitledOpen.setPath(path);
-			sameTitledOpen.setType(type);
-			sameTitledOpen.setContentValid(true);
+			sameTitledOpen.path = path;
+			sameTitledOpen.invalidateContent();
+			sameTitledOpen.setDecompilerReferences(metadataSystem, settings, decompilationOptions);
+			sameTitledOpen.setType(resolvedType);
+			sameTitledOpen.setInitialNavigationLink(navigatonLink);
+			sameTitledOpen.resetScrollPosition();
+			sameTitledOpen.decompile();
 			addOrSwitchToTab(sameTitledOpen);
 		} else {
-			OpenFile open = new OpenFile(type, tabTitle, path, decompiledSource, theme);
-			open.setContentValid(true);
+			OpenFile open = new OpenFile(tabTitle, path, theme, mainWindow);
+			open.setDecompilerReferences(metadataSystem, settings, decompilationOptions);
+			open.setType(resolvedType);
+			open.setInitialNavigationLink(navigatonLink);
+			open.decompile();
 			hmap.add(open);
 			addOrSwitchToTab(open);
-		}
-	}
-
-	private String extractClassToString(TypeReference type) throws Exception {
-		// synchronized: do not accept changes from menu while running
-		synchronized (settings) {
-			TypeDefinition resolvedType = null;
-			if (type == null || ((resolvedType = type.resolve()) == null)) {
-				throw new Exception("Unable to resolve type.");
-			}
-			StringWriter stringwriter = new StringWriter();
-			settings.getLanguage().decompileType(resolvedType,
-					new PlainTextOutput(stringwriter), decompilationOptions);
-
-			if (configSaver.isUnicodeReplaceEnabled()) {
-				String javaCode = stringwriter.toString();
-				Pattern p = Pattern.compile("\\\\u(\\p{XDigit}{4})");
-				Matcher m = p.matcher(javaCode);
-				StringBuffer buf = new StringBuffer(javaCode.length());
-				while (m.find()) {
-					String ch = String.valueOf((char) Integer.parseInt(m.group(1), 16));
-					m.appendReplacement(buf, Matcher.quoteReplacement(ch));
-				}
-				m.appendTail(buf);
-				return buf.toString();
-			}
-			return stringwriter.toString();
 		}
 	}
 
@@ -367,7 +362,7 @@ public class Model extends JSplitPane {
 				break;
 			}
 		}
-		if (sameTitledOpen != null && path.equals(sameTitledOpen.getPath())) {
+		if (sameTitledOpen != null && path.equals(sameTitledOpen.path)) {
 			addOrSwitchToTab(sameTitledOpen);
 			return;
 		}
@@ -400,11 +395,15 @@ public class Model extends JSplitPane {
 
 		// open tab
 		if (sameTitledOpen != null) {
+			sameTitledOpen.path = path;
+			sameTitledOpen.setDecompilerReferences(metadataSystem, settings, decompilationOptions);
+			sameTitledOpen.resetScrollPosition();
 			sameTitledOpen.setContent(sb.toString());
-			sameTitledOpen.setPath(path);
 			addOrSwitchToTab(sameTitledOpen);
 		} else {
-			OpenFile open = new OpenFile(tabTitle, path, sb.toString(), theme);
+			OpenFile open = new OpenFile(tabTitle, path, theme, mainWindow);
+			open.setDecompilerReferences(metadataSystem, settings, decompilationOptions);
+			open.setContent(sb.toString());
 			hmap.add(open);
 			addOrSwitchToTab(open);
 		}
@@ -433,12 +432,8 @@ public class Model extends JSplitPane {
 	public void updateOpenClasses() {
 		// invalidate all open classes (update will hapen at tab change)
 		for (OpenFile open : hmap) {
-			open.setContentValid(false);
-		}
-		// ensure not showing old codes
-		for (OpenFile open : hmap) {
 			if (open.getType() != null) {
-				open.setContent("");
+				open.invalidateContent();
 			}
 		}
 		// update the current open tab - if it is a class
@@ -460,9 +455,8 @@ public class Model extends JSplitPane {
 				try {
 					bar.setVisible(true);
 					label.setText("Extracting: " + open.name);
-					String decompiledSource = extractClassToString(open.getType());
-					open.setContent(decompiledSource);
-					open.setContentValid(true);
+					open.invalidateContent();
+					open.decompile();
 					label.setText("Complete");
 				} catch (Exception e) {
 					label.setText("Error, cannot update: " + open.name);
@@ -495,7 +489,7 @@ public class Model extends JSplitPane {
 		@Override
 		public void close() {
 			if (typeLoader != null) {
-				Model.this.typeLoader.getTypeLoaders().remove(typeLoader);
+				Model.typeLoader.getTypeLoaders().remove(typeLoader);
 			}
 			Closer.tryClose(jarFile);
 		}
@@ -815,6 +809,7 @@ public class Model extends JSplitPane {
 			int pos = house.indexOfTab(co.name);
 			if (pos >= 0)
 				house.remove(pos);
+			co.close();
 		}
 
 		final State oldState = state;
@@ -906,7 +901,8 @@ public class Model extends JSplitPane {
 					settings.getLanguage().decompileType(resolvedType,
 							new PlainTextOutput(stringwriter), decompilationOptions);
 					String decompiledSource = stringwriter.toString();
-					OpenFile open = new OpenFile(internalName, "*/" + internalName, decompiledSource, theme);
+					OpenFile open = new OpenFile(internalName, "*/" + internalName, theme, mainWindow);
+					open.setContent(decompiledSource);
 					JTabbedPane pane = new JTabbedPane();
 					pane.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
 					pane.addTab("title", open.scrollPane);
@@ -916,5 +912,40 @@ public class Model extends JSplitPane {
 				}
 			}
 		}.start();
+	}
+
+	public void navigateTo(final String uniqueStr) {
+		new Thread(new Runnable() {
+			@Override
+			public void run() {
+				if (uniqueStr == null)
+					return;
+				String[] linkParts = uniqueStr.split("\\|");
+				if (linkParts.length <= 1)
+					return;
+				String destinationTypeStr = linkParts[1];
+				try {
+					bar.setVisible(true);
+					label.setText("Navigating: " + destinationTypeStr.replaceAll("/", "."));
+
+					TypeReference type = metadataSystem.lookupType(destinationTypeStr);
+					if (type == null)
+						throw new RuntimeException("Cannot lookup type: " + destinationTypeStr);
+					TypeDefinition typeDef = type.resolve();
+					if (typeDef == null)
+						throw new RuntimeException("Cannot resolve type: " + destinationTypeStr);
+
+					String tabTitle = typeDef.getName() + ".class";
+					extractClassToTextPane(typeDef, tabTitle, destinationTypeStr, uniqueStr);
+
+					label.setText("Complete");
+				} catch (Exception e) {
+					label.setText("Cannot navigate: " + destinationTypeStr.replaceAll("/", "."));
+					e.printStackTrace();
+				} finally {
+					bar.setVisible(false);
+				}
+			}
+		}).start();
 	}
 }

--- a/src/us/deathmarine/luyten/Model.java
+++ b/src/us/deathmarine/luyten/Model.java
@@ -898,8 +898,9 @@ public class Model extends JSplitPane {
 						return;
 					}
 					StringWriter stringwriter = new StringWriter();
-					settings.getLanguage().decompileType(resolvedType,
-							new PlainTextOutput(stringwriter), decompilationOptions);
+					PlainTextOutput plainTextOutput = new PlainTextOutput(stringwriter);
+					plainTextOutput.setUnicodeOutputEnabled(decompilationOptions.getSettings().isUnicodeOutputEnabled());
+					settings.getLanguage().decompileType(resolvedType, plainTextOutput, decompilationOptions);
 					String decompiledSource = stringwriter.toString();
 					OpenFile open = new OpenFile(internalName, "*/" + internalName, theme, mainWindow);
 					open.setContent(decompiledSource);

--- a/src/us/deathmarine/luyten/OpenFile.java
+++ b/src/us/deathmarine/luyten/OpenFile.java
@@ -1,13 +1,37 @@
 package us.deathmarine.luyten;
 
+import java.awt.Cursor;
 import java.awt.Panel;
+import java.awt.Rectangle;
+import java.awt.event.AdjustmentEvent;
+import java.awt.event.AdjustmentListener;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
+import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.swing.JLabel;
+import javax.swing.JScrollBar;
+import javax.swing.ScrollPaneConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.event.HyperlinkEvent;
+import org.fife.ui.rsyntaxtextarea.LinkGenerator;
+import org.fife.ui.rsyntaxtextarea.LinkGeneratorResult;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.fife.ui.rsyntaxtextarea.Theme;
 import org.fife.ui.rtextarea.RTextScrollPane;
-import com.strobel.assembler.metadata.TypeReference;
+import com.strobel.assembler.metadata.MetadataSystem;
+import com.strobel.assembler.metadata.TypeDefinition;
+import com.strobel.decompiler.DecompilationOptions;
+import com.strobel.decompiler.DecompilerSettings;
+import com.strobel.decompiler.PlainTextOutput;
+import com.strobel.decompiler.languages.Languages;
 
 public class OpenFile implements SyntaxConstants {
 
@@ -16,22 +40,37 @@ public class OpenFile implements SyntaxConstants {
 			".phtml", ".html", ".htm", ".xhtm", ".xhtml", ".lua", ".bat", ".pl", ".sh", ".css",
 			".json", ".txt", ".rb", ".make", ".mak", ".py", ".properties", ".prop"));
 
+	// navigation links
+	private TreeMap<Selection, String> selectionToUniqueStrTreeMap = new TreeMap<>();
+	private Map<String, Boolean> isNavigableCache = new ConcurrentHashMap<>();
+	private Map<String, String> readableLinksCache = new ConcurrentHashMap<>();
+
+	private volatile boolean isContentValid = false;
+	private volatile boolean isNavigationLinksValid = false;
+	private volatile boolean isWaitForLinksCursor = false;
+	private volatile Double lastScrollPercent = null;
+
+	private LinkProvider linkProvider;
+	private String initialNavigationLink;
+	private boolean isFirstTimeRun = true;
+
+	MainWindow mainWindow;
 	RTextScrollPane scrollPane;
 	Panel image_pane;
 	RSyntaxTextArea textArea;
 	String name;
-	private String path;
-	private TypeReference type = null;
-	private boolean isContentValid = false;
+	String path;
 
-	public OpenFile(TypeReference type, String name, String path, String content, Theme theme) {
-		this(name, path, content, theme);
-		this.type = type;
-	}
-	
-	public OpenFile(String name, String path, String contents, Theme theme) {
+	// decompiler and type references (not needed for text files)
+	private MetadataSystem metadataSystem;
+	private DecompilerSettings settings;
+	private DecompilationOptions decompilationOptions;
+	private TypeDefinition type;
+
+	public OpenFile(String name, String path, Theme theme, MainWindow mainWindow) {
 		this.name = name;
 		this.path = path;
+		this.mainWindow = mainWindow;
 		textArea = new RSyntaxTextArea(25, 70);
 		textArea.setCaretPosition(0);
 		textArea.requestFocusInWindow();
@@ -90,27 +129,420 @@ public class OpenFile implements SyntaxConstants {
 			textArea.setSyntaxEditingStyle(SYNTAX_STYLE_PROPERTIES_FILE);
 		scrollPane = new RTextScrollPane(textArea, true);
 		scrollPane.setIconRowHeaderEnabled(true);
-		textArea.setText(contents);
+		textArea.setText("");
 		theme.apply(textArea);
+
+		scrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
+		final JScrollBar verticalScrollbar = scrollPane.getVerticalScrollBar();
+		if (verticalScrollbar != null) {
+			verticalScrollbar.addAdjustmentListener(new AdjustmentListener() {
+				@Override
+				public void adjustmentValueChanged(AdjustmentEvent e) {
+					String content = textArea.getText();
+					if (content == null || content.length() == 0)
+						return;
+					int scrollValue = verticalScrollbar.getValue() - verticalScrollbar.getMinimum();
+					int scrollMax = verticalScrollbar.getMaximum() - verticalScrollbar.getMinimum();
+					if (scrollMax < 1 || scrollValue < 0 || scrollValue > scrollMax)
+						return;
+					lastScrollPercent = (((double) scrollValue) / ((double) scrollMax));
+				}
+			});
+		}
+
+		textArea.setHyperlinksEnabled(true);
+		textArea.setLinkScanningMask(InputEvent.CTRL_DOWN_MASK);
+
+		textArea.setLinkGenerator(new LinkGenerator() {
+			@Override
+			public LinkGeneratorResult isLinkAtOffset(RSyntaxTextArea textArea, final int offs) {
+				final String uniqueStr = getUniqueStrForOffset(offs);
+				final Integer selectionFrom = getSelectionFromForOffset(offs);
+				if (uniqueStr != null && selectionFrom != null) {
+					return new LinkGeneratorResult() {
+						@Override
+						public HyperlinkEvent execute() {
+							if (isNavigationLinksValid)
+								onNavigationClicked(uniqueStr);
+							return null;
+						}
+
+						@Override
+						public int getSourceOffset() {
+							if (isNavigationLinksValid)
+								return selectionFrom;
+							return offs;
+						}
+					};
+				}
+				return null;
+			}
+		});
+
+		textArea.addMouseMotionListener(new MouseMotionAdapter() {
+			private boolean isLinkLabelPrev = false;
+			private String prevLinkText = null;
+
+			@Override
+			public synchronized void mouseMoved(MouseEvent e) {
+				String linkText = null;
+				boolean isLinkLabel = false;
+				boolean isCtrlDown = (e.getModifiersEx() & InputEvent.CTRL_DOWN_MASK) != 0;
+				if (isCtrlDown) {
+					linkText = createLinkLabel(e);
+					isLinkLabel = linkText != null;
+				}
+				if (isCtrlDown && isWaitForLinksCursor) {
+					textArea.setCursor(new Cursor(Cursor.WAIT_CURSOR));
+				} else if (textArea.getCursor().getType() == Cursor.WAIT_CURSOR) {
+					textArea.setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
+				}
+
+				JLabel label = OpenFile.this.mainWindow.getLabel();
+
+				if (isLinkLabel && isLinkLabelPrev) {
+					if (!linkText.equals(prevLinkText)) {
+						setLinkLabel(label, linkText);
+					}
+				} else if (isLinkLabel && !isLinkLabelPrev) {
+					setLinkLabel(label, linkText);
+
+				} else if (!isLinkLabel && isLinkLabelPrev) {
+					setLinkLabel(label, null);
+				}
+				isLinkLabelPrev = isLinkLabel;
+				prevLinkText = linkText;
+			}
+
+			private void setLinkLabel(JLabel label, String text) {
+				String current = label.getText();
+				if (text == null && current != null)
+					if (current.startsWith("Navigating:") || current.startsWith("Cannot navigate:"))
+						return;
+				label.setText(text != null ? text : "Complete");
+			}
+
+			private String createLinkLabel(MouseEvent e) {
+				int offs = textArea.viewToModel(e.getPoint());
+				if (isNavigationLinksValid) {
+					return getLinkDescriptionForOffset(offs);
+				}
+				return null;
+			}
+		});
 	}
 
 	public void setContent(String content) {
 		textArea.setText(content);
 	}
 
-	public String getPath() {
-		return path;
+	public void decompile() {
+		this.invalidateContent();
+		// synchronized: do not accept changes from menu while running
+		synchronized (settings) {
+			if (Languages.java().getName().equals(settings.getLanguage().getName())) {
+				decompileWithNavigationLinks();
+			} else {
+				decompileWithoutLinks();
+			}
+		}
 	}
 
-	public void setPath(String path) {
-		this.path = path;
+	private void decompileWithoutLinks() {
+		this.invalidateContent();
+		isNavigationLinksValid = false;
+		textArea.setHyperlinksEnabled(false);
+
+		StringWriter stringwriter = new StringWriter();
+		settings.getLanguage().decompileType(type, new PlainTextOutput(stringwriter), decompilationOptions);
+		setContentPreserveLastScrollPosition(stringwriter.toString());
+		this.isContentValid = true;
 	}
 
-	public TypeReference getType() {
+	private void decompileWithNavigationLinks() {
+		this.invalidateContent();
+		DecompilerLinkProvider newLinkProvider = new DecompilerLinkProvider();
+		newLinkProvider.setDecompilerReferences(metadataSystem, settings, decompilationOptions);
+		newLinkProvider.setType(type);
+		linkProvider = newLinkProvider;
+
+		linkProvider.generateContent();
+		setContentPreserveLastScrollPosition(linkProvider.getTextContent());
+		this.isContentValid = true;
+		enableLinks();
+	}
+
+	private void setContentPreserveLastScrollPosition(final String content) {
+		final Double scrollPercent = lastScrollPercent;
+		if (scrollPercent != null && initialNavigationLink == null) {
+			SwingUtilities.invokeLater(new Runnable() {
+				@Override
+				public void run() {
+					textArea.setText(content);
+					restoreScrollPosition(scrollPercent);
+				}
+			});
+		} else {
+			textArea.setText(content);
+		}
+	}
+
+	private void restoreScrollPosition(final double position) {
+		SwingUtilities.invokeLater(new Runnable() {
+			@Override
+			public void run() {
+				JScrollBar verticalScrollbar = scrollPane.getVerticalScrollBar();
+				if (verticalScrollbar == null)
+					return;
+				int scrollMax = verticalScrollbar.getMaximum() - verticalScrollbar.getMinimum();
+				long newScrollValue = Math.round(position * scrollMax) + verticalScrollbar.getMinimum();
+				if (newScrollValue < verticalScrollbar.getMinimum())
+					newScrollValue = verticalScrollbar.getMinimum();
+				if (newScrollValue > verticalScrollbar.getMaximum())
+					newScrollValue = verticalScrollbar.getMaximum();
+				verticalScrollbar.setValue((int) newScrollValue);
+			}
+		});
+	}
+
+	private void enableLinks() {
+		if (initialNavigationLink != null) {
+			doEnableLinks();
+		} else {
+			new Thread(new Runnable() {
+				@Override
+				public void run() {
+					try {
+						isWaitForLinksCursor = true;
+						doEnableLinks();
+					} finally {
+						isWaitForLinksCursor = false;
+						resetCursor();
+					}
+				}
+			}).start();
+		}
+	}
+
+	private void resetCursor() {
+		SwingUtilities.invokeLater(new Runnable() {
+			@Override
+			public void run() {
+				textArea.setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
+			}
+		});
+	}
+
+	private void doEnableLinks() {
+		isNavigationLinksValid = false;
+		linkProvider.processLinks();
+		buildSelectionToUniqueStrTreeMap();
+		clearLinksCache();
+		isNavigationLinksValid = true;
+		textArea.setHyperlinksEnabled(true);
+		warmUpWithFirstLink();
+	}
+
+	private void warmUpWithFirstLink() {
+		if (selectionToUniqueStrTreeMap.keySet().size() > 0) {
+			Selection selection = selectionToUniqueStrTreeMap.keySet().iterator().next();
+			getLinkDescriptionForOffset(selection.from);
+		}
+	}
+
+	public void clearLinksCache() {
+		try {
+			isNavigableCache.clear();
+			readableLinksCache.clear();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	private void buildSelectionToUniqueStrTreeMap() {
+		TreeMap<Selection, String> treeMap = new TreeMap<>();
+		Map<String, Selection> definitionToSelectionMap = linkProvider.getDefinitionToSelectionMap();
+		Map<String, Set<Selection>> referenceToSelectionsMap = linkProvider.getReferenceToSelectionsMap();
+
+		for (String key : definitionToSelectionMap.keySet()) {
+			Selection selection = definitionToSelectionMap.get(key);
+			treeMap.put(selection, key);
+		}
+		for (String key : referenceToSelectionsMap.keySet()) {
+			for (Selection selection : referenceToSelectionsMap.get(key)) {
+				treeMap.put(selection, key);
+			}
+		}
+		selectionToUniqueStrTreeMap = treeMap;
+	}
+
+	private Selection getSelectionForOffset(int offset) {
+		if (isNavigationLinksValid) {
+			Selection offsetSelection = new Selection(offset, offset);
+			Selection floorSelection = selectionToUniqueStrTreeMap.floorKey(offsetSelection);
+			if (floorSelection != null && floorSelection.from <= offset && floorSelection.to > offset) {
+				return floorSelection;
+			}
+		}
+		return null;
+	}
+
+	private String getUniqueStrForOffset(int offset) {
+		Selection selection = getSelectionForOffset(offset);
+		if (selection != null) {
+			String uniqueStr = selectionToUniqueStrTreeMap.get(selection);
+			if (this.isLinkNavigable(uniqueStr) && this.getLinkDescription(uniqueStr) != null) {
+				return uniqueStr;
+			}
+		}
+		return null;
+	}
+
+	private Integer getSelectionFromForOffset(int offset) {
+		Selection selection = getSelectionForOffset(offset);
+		if (selection != null) {
+			return selection.from;
+		}
+		return null;
+	}
+
+	private String getLinkDescriptionForOffset(int offset) {
+		String uniqueStr = getUniqueStrForOffset(offset);
+		if (uniqueStr != null) {
+			String description = this.getLinkDescription(uniqueStr);
+			if (description != null) {
+				return description;
+			}
+		}
+		return null;
+	}
+
+	private boolean isLinkNavigable(String uniqueStr) {
+		try {
+			Boolean isNavigableCached = isNavigableCache.get(uniqueStr);
+			if (isNavigableCached != null)
+				return isNavigableCached;
+
+			boolean isNavigable = linkProvider.isLinkNavigable(uniqueStr);
+			isNavigableCache.put(uniqueStr, isNavigable);
+			return isNavigable;
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return false;
+	}
+
+	private String getLinkDescription(String uniqueStr) {
+		try {
+			String descriptionCached = readableLinksCache.get(uniqueStr);
+			if (descriptionCached != null)
+				return descriptionCached;
+
+			String description = linkProvider.getLinkDescription(uniqueStr);
+			if (description != null && description.trim().length() > 0) {
+				readableLinksCache.put(uniqueStr, description);
+				return description;
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	private void onNavigationClicked(String clickedReferenceUniqueStr) {
+		if (isLocallyNavigable(clickedReferenceUniqueStr)) {
+			onLocalNavigationRequest(clickedReferenceUniqueStr);
+		} else if (linkProvider.isLinkNavigable(clickedReferenceUniqueStr)) {
+			onOutboundNavigationRequest(clickedReferenceUniqueStr);
+		} else {
+			JLabel label = this.mainWindow.getLabel();
+			if (label == null)
+				return;
+			String[] linkParts = clickedReferenceUniqueStr.split("\\|");
+			if (linkParts.length <= 1) {
+				label.setText("Cannot navigate: " + clickedReferenceUniqueStr);
+				return;
+			}
+			String destinationTypeStr = linkParts[1];
+			label.setText("Cannot navigate: " + destinationTypeStr.replaceAll("/", "."));
+		}
+	}
+
+	private boolean isLocallyNavigable(String uniqueStr) {
+		return linkProvider.getDefinitionToSelectionMap().keySet().contains(uniqueStr);
+	}
+
+	private void onLocalNavigationRequest(String uniqueStr) {
+		try {
+			Selection selection = linkProvider.getDefinitionToSelectionMap().get(uniqueStr);
+			doLocalNavigation(selection);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	private void doLocalNavigation(Selection selection) {
+		try {
+			textArea.requestFocusInWindow();
+			if (selection != null) {
+				textArea.setSelectionStart(selection.from);
+				textArea.setSelectionEnd(selection.to);
+				scrollToSelection(selection.from);
+			} else {
+				textArea.setSelectionStart(0);
+				textArea.setSelectionEnd(0);
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	private void scrollToSelection(final int selectionBeginningOffset) {
+		SwingUtilities.invokeLater(new Runnable() {
+			@Override
+			public void run() {
+				try {
+					int fullHeight = textArea.getBounds().height;
+					int viewportHeight = textArea.getVisibleRect().height;
+					int viewportLineCount = viewportHeight / textArea.getLineHeight();
+					int selectionLineNum = textArea.getLineOfOffset(selectionBeginningOffset);
+					int upperMarginToScroll = Math.round(viewportLineCount * 0.29f);
+					int upperLineToSet = selectionLineNum - upperMarginToScroll;
+					int currentUpperLine = textArea.getVisibleRect().y / textArea.getLineHeight();
+
+					if (selectionLineNum <= currentUpperLine + 2 ||
+							selectionLineNum >= currentUpperLine + viewportLineCount - 4) {
+						Rectangle rectToScroll = new Rectangle();
+						rectToScroll.x = 0;
+						rectToScroll.width = 1;
+						rectToScroll.y = Math.max(upperLineToSet * textArea.getLineHeight(), 0);
+						rectToScroll.height = Math.min(viewportHeight, fullHeight - rectToScroll.y);
+						textArea.scrollRectToVisible(rectToScroll);
+					}
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		});
+	}
+
+	private void onOutboundNavigationRequest(String uniqueStr) {
+		mainWindow.onNavigationRequest(uniqueStr);
+	}
+
+	public void setDecompilerReferences(MetadataSystem metadataSystem,
+			DecompilerSettings settings,
+			DecompilationOptions decompilationOptions) {
+		this.metadataSystem = metadataSystem;
+		this.settings = settings;
+		this.decompilationOptions = decompilationOptions;
+	}
+
+	public TypeDefinition getType() {
 		return type;
 	}
 
-	public void setType(TypeReference type) {
+	public void setType(TypeDefinition type) {
 		this.type = type;
 	}
 
@@ -118,10 +550,48 @@ public class OpenFile implements SyntaxConstants {
 		return isContentValid;
 	}
 
-	public void setContentValid(boolean isContentValid) {
-		this.isContentValid = isContentValid;
+	public void invalidateContent() {
+		try {
+			this.setContent("");
+		} finally {
+			this.isContentValid = false;
+			this.isNavigationLinksValid = false;
+		}
 	}
-	
+
+	public void resetScrollPosition() {
+		lastScrollPercent = null;
+	}
+
+	public void setInitialNavigationLink(String initialNavigationLink) {
+		this.initialNavigationLink = initialNavigationLink;
+	}
+
+	public void onAddedToScreen() {
+		try {
+			if (initialNavigationLink != null) {
+				onLocalNavigationRequest(initialNavigationLink);
+			} else if (isFirstTimeRun) {
+				// warm up scrolling
+				isFirstTimeRun = false;
+				doLocalNavigation(new Selection(0, 0));
+			}
+		} finally {
+			initialNavigationLink = null;
+		}
+	}
+
+	/**
+	 * sun.swing.CachedPainter holds on OpenFile for a while
+	 * even after JTabbedPane.remove(component)
+	 */
+	public void close() {
+		linkProvider = null;
+		type = null;
+		invalidateContent();
+		clearLinksCache();
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
@@ -146,4 +616,32 @@ public class OpenFile implements SyntaxConstants {
 			return false;
 		return true;
 	}
+	
+//	private String extractClassToString(TypeReference type) throws Exception {
+//		// synchronized: do not accept changes from menu while running
+//		synchronized (settings) {
+//			TypeDefinition resolvedType = null;
+//			if (type == null || ((resolvedType = type.resolve()) == null)) {
+//				throw new Exception("Unable to resolve type.");
+//			}
+//			StringWriter stringwriter = new StringWriter();
+//			settings.getLanguage().decompileType(resolvedType,
+//					new PlainTextOutput(stringwriter), decompilationOptions);
+//
+//			if (configSaver.isUnicodeReplaceEnabled()) {
+//				String javaCode = stringwriter.toString();
+//				Pattern p = Pattern.compile("\\\\u(\\p{XDigit}{4})");
+//				Matcher m = p.matcher(javaCode);
+//				StringBuffer buf = new StringBuffer(javaCode.length());
+//				while (m.find()) {
+//					String ch = String.valueOf((char) Integer.parseInt(m.group(1), 16));
+//					m.appendReplacement(buf, Matcher.quoteReplacement(ch));
+//				}
+//				m.appendTail(buf);
+//				return buf.toString();
+//			}
+//			return stringwriter.toString();
+//		}
+//	}
+
 }

--- a/src/us/deathmarine/luyten/OpenFile.java
+++ b/src/us/deathmarine/luyten/OpenFile.java
@@ -254,7 +254,9 @@ public class OpenFile implements SyntaxConstants {
 		textArea.setHyperlinksEnabled(false);
 
 		StringWriter stringwriter = new StringWriter();
-		settings.getLanguage().decompileType(type, new PlainTextOutput(stringwriter), decompilationOptions);
+		PlainTextOutput plainTextOutput = new PlainTextOutput(stringwriter);
+		plainTextOutput.setUnicodeOutputEnabled(decompilationOptions.getSettings().isUnicodeOutputEnabled());
+		settings.getLanguage().decompileType(type, plainTextOutput, decompilationOptions);
 		setContentPreserveLastScrollPosition(stringwriter.toString());
 		this.isContentValid = true;
 	}
@@ -617,31 +619,4 @@ public class OpenFile implements SyntaxConstants {
 		return true;
 	}
 	
-//	private String extractClassToString(TypeReference type) throws Exception {
-//		// synchronized: do not accept changes from menu while running
-//		synchronized (settings) {
-//			TypeDefinition resolvedType = null;
-//			if (type == null || ((resolvedType = type.resolve()) == null)) {
-//				throw new Exception("Unable to resolve type.");
-//			}
-//			StringWriter stringwriter = new StringWriter();
-//			settings.getLanguage().decompileType(resolvedType,
-//					new PlainTextOutput(stringwriter), decompilationOptions);
-//
-//			if (configSaver.isUnicodeReplaceEnabled()) {
-//				String javaCode = stringwriter.toString();
-//				Pattern p = Pattern.compile("\\\\u(\\p{XDigit}{4})");
-//				Matcher m = p.matcher(javaCode);
-//				StringBuffer buf = new StringBuffer(javaCode.length());
-//				while (m.find()) {
-//					String ch = String.valueOf((char) Integer.parseInt(m.group(1), 16));
-//					m.appendReplacement(buf, Matcher.quoteReplacement(ch));
-//				}
-//				m.appendTail(buf);
-//				return buf.toString();
-//			}
-//			return stringwriter.toString();
-//		}
-//	}
-
 }

--- a/src/us/deathmarine/luyten/Selection.java
+++ b/src/us/deathmarine/luyten/Selection.java
@@ -1,0 +1,41 @@
+package us.deathmarine.luyten;
+
+public class Selection implements Comparable<Selection> {
+	public final Integer from;
+	public final Integer to;
+
+	public Selection(Integer from, Integer to) {
+		this.from = from;
+		this.to = to;
+	}
+
+	@Override
+	public int compareTo(Selection o) {
+		return from.compareTo(o.from);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((from == null) ? 0 : from.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Selection other = (Selection) obj;
+		if (from == null) {
+			if (other.from != null)
+				return false;
+		} else if (!from.equals(other.from))
+			return false;
+		return true;
+	}
+}


### PR DESCRIPTION
Hi,

I added support for CTRL+Click navigation, as mentioned in issue: Improve classes navigation functionality #28. Also, when you move the mouse over a valid link (with CTRL pressed), a short descripction appears in the status bar about the destination of the link. Types, Methods and Fields can be navigated, local variables not.

Your Enable Unicode Replacement functionality was tricky to merge, because originally it changed the decompiled code after get from decompiler, and so the java references Start and End character positions has beed modified. Luckily, now this functionality is a part of Procyon, so it can do replacement for us during decompilation. 

Now, Save and Save All also changes it's output if Enable Unicode Replacement checked (in this case generates UTF-8 output), and saves even chinese characters (hyperlinks also works with chinese characters present in java reference names, I tried it, but only if Enable Unicode Replacement checked).

I want to go on with Navigation History and Recent Files features, as soon as I have time.

Regards,
Zoltan Erdei