### PR TITLE
Fixed filesaver not saving non-java files

### DIFF
--- a/src/us/deathmarine/luyten/FileSaver.java
+++ b/src/us/deathmarine/luyten/FileSaver.java
@@ -198,11 +198,11 @@ public class FileSaver {
 					try {
 						JarEntry etn = new JarEntry(entry.getName());
 						if(history.add(etn))
-							continue;
+						{
 						history.add(etn);
 						out.putNextEntry(etn);
 						try {
-							InputStream in = jfile.getInputStream(entry);
+							InputStream in = jfile.getInputStream(etn);
 							if (in != null) {
 								try {
 									int count;
@@ -216,7 +216,8 @@ public class FileSaver {
 						} finally {
 							out.closeEntry();
 						}
-					} catch (ZipException ze) {
+					}
+				} catch (ZipException ze) {
 						// some jar-s contain duplicate pom.xml entries: ignore it
 						if (!ze.getMessage().contains("duplicate")) {
 							throw ze;


### PR DESCRIPTION
Fixed the FileSaver class not saving non-java files, old pull request was on the wrong github account.