### PR TITLE
Fixed broken and unencrypted links

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -10,7 +10,7 @@ Apache License, Version 2.0
 
 We use maven to handle our dependencies.
 
-* Install [Maven 3](http://maven.apache.org/download.html)
+* Install [Maven 3](https://maven.apache.org/download.html)
 * Clone this repo and: `mvn clean install`
 
 ## Screenshot
@@ -29,10 +29,10 @@ We use maven to handle our dependencies.
 ### Procyon
 &copy; 2015 Mike Strobel  
 [https://bitbucket.org/mstrobel/procyon/overview](https://bitbucket.org/mstrobel/procyon/overview)  
-[Apache License](https://github.com/deathmarine/Luyten/blob/master/distfiles/Procyon.License.txt)  
+[Apache License](https://github.com/deathmarine/Luyten/blob/master/src/distfiles/Procyon.License.txt)  
 
 
 ### RSyntaxTextArea
 &copy; 2012 Robert Futrell  
-[http://fifesoft.com/rsyntaxtextarea/](http://fifesoft.com/rsyntaxtextarea/)  
-[All Rights Reserved](https://github.com/deathmarine/Luyten/blob/master/distfiles/RSyntaxTextArea.License.txt)
+[https://bobbylight.github.io/RSyntaxTextArea/](https://bobbylight.github.io/RSyntaxTextArea/)
+[All Rights Reserved](https://github.com/deathmarine/Luyten/blob/master/src/distfiles/RSyntaxTextArea.License.txt)


### PR DESCRIPTION
Just some minor fixes for ReadMe.md, which currently has a few broken links and is missing HTTPS in the Maven link.