### PR TITLE
Refactored the file dialog preferences

### DIFF
--- a/src/us/deathmarine/luyten/DirPreferences.java
+++ b/src/us/deathmarine/luyten/DirPreferences.java
@@ -3,10 +3,10 @@ package us.deathmarine.luyten;
 import javax.swing.*;
 import java.io.File;
 
-class ExtractedFileDialog {
+class DirPreferences {
     private LuytenPreferences luytenPrefs;
 
-    public ExtractedFileDialog(LuytenPreferences luytenPrefs) {
+    public DirPreferences(LuytenPreferences luytenPrefs) {
         this.luytenPrefs = luytenPrefs;
     }
 

--- a/src/us/deathmarine/luyten/ExtractedFileDialog.java
+++ b/src/us/deathmarine/luyten/ExtractedFileDialog.java
@@ -1,0 +1,62 @@
+package us.deathmarine.luyten;
+
+import javax.swing.*;
+import java.io.File;
+
+class ExtractedFileDialog {
+    private LuytenPreferences luytenPrefs;
+
+    public ExtractedFileDialog(LuytenPreferences luytenPrefs) {
+        this.luytenPrefs = luytenPrefs;
+    }
+
+    void retrieveOpenDialogDir(JFileChooser fc) {
+        try {
+            String currentDirStr = luytenPrefs.getFileOpenCurrentDirectory();
+            if (currentDirStr != null && currentDirStr.trim().length() > 0) {
+                File currentDir = new File(currentDirStr);
+                if (currentDir.exists() && currentDir.isDirectory()) {
+                    fc.setCurrentDirectory(currentDir);
+                }
+            }
+        } catch (Exception e) {
+            Luyten.showExceptionDialog("Exception!", e);
+        }
+    }
+
+    void saveOpenDialogDir(JFileChooser fc) {
+        try {
+            File currentDir = fc.getCurrentDirectory();
+            if (currentDir != null && currentDir.exists() && currentDir.isDirectory()) {
+                luytenPrefs.setFileOpenCurrentDirectory(currentDir.getAbsolutePath());
+            }
+        } catch (Exception e) {
+            Luyten.showExceptionDialog("Exception!", e);
+        }
+    }
+
+    void retrieveSaveDialogDir(JFileChooser fc) {
+        try {
+            String currentDirStr = luytenPrefs.getFileSaveCurrentDirectory();
+            if (currentDirStr != null && currentDirStr.trim().length() > 0) {
+                File currentDir = new File(currentDirStr);
+                if (currentDir.exists() && currentDir.isDirectory()) {
+                    fc.setCurrentDirectory(currentDir);
+                }
+            }
+        } catch (Exception e) {
+            Luyten.showExceptionDialog("Exception!", e);
+        }
+    }
+
+    void saveSaveDialogDir(JFileChooser fc) {
+        try {
+            File currentDir = fc.getCurrentDirectory();
+            if (currentDir != null && currentDir.exists() && currentDir.isDirectory()) {
+                luytenPrefs.setFileSaveCurrentDirectory(currentDir.getAbsolutePath());
+            }
+        } catch (Exception e) {
+            Luyten.showExceptionDialog("Exception!", e);
+        }
+    }
+}

--- a/src/us/deathmarine/luyten/FileDialog.java
+++ b/src/us/deathmarine/luyten/FileDialog.java
@@ -9,9 +9,9 @@ import javax.swing.filechooser.FileFilter;
  * FileChoosers for Open and Save
  */
 public class FileDialog {
-	private ConfigSaver configSaver;
-	private LuytenPreferences luytenPrefs;
-	private Component parent;
+    private final ExtractedFileDialog extractedFileDialog;
+    private ConfigSaver configSaver;
+    private Component parent;
 	private JFileChooser fcOpen;
 	private JFileChooser fcSave;
 	private JFileChooser fcSaveAll;
@@ -19,9 +19,10 @@ public class FileDialog {
 	public FileDialog(Component parent) {
 		this.parent = parent;
 		configSaver = ConfigSaver.getLoadedInstance();
-		luytenPrefs = configSaver.getLuytenPreferences();
+        LuytenPreferences luytenPrefs = configSaver.getLuytenPreferences();
+        extractedFileDialog = new ExtractedFileDialog(luytenPrefs);
 
-		new Thread() {
+        new Thread() {
 			public void run() {
 				try {
 					initOpenDialog();
@@ -40,9 +41,9 @@ public class FileDialog {
 		File selectedFile = null;
 		initOpenDialog();
 
-		retrieveOpenDialogDir(fcOpen);
+        extractedFileDialog.retrieveOpenDialogDir(fcOpen);
 		int returnVal = fcOpen.showOpenDialog(parent);
-		saveOpenDialogDir(fcOpen);
+        extractedFileDialog.saveOpenDialogDir(fcOpen);
 
 		if (returnVal == JFileChooser.APPROVE_OPTION) {
 			selectedFile = fcOpen.getSelectedFile();
@@ -54,10 +55,10 @@ public class FileDialog {
 		File selectedFile = null;
 		initSaveDialog();
 
-		retrieveSaveDialogDir(fcSave);
+        extractedFileDialog.retrieveSaveDialogDir(fcSave);
 		fcSave.setSelectedFile(new File(recommendedFileName));
 		int returnVal = fcSave.showSaveDialog(parent);
-		saveSaveDialogDir(fcSave);
+        extractedFileDialog.saveSaveDialogDir(fcSave);
 
 		if (returnVal == JFileChooser.APPROVE_OPTION) {
 			selectedFile = fcSave.getSelectedFile();
@@ -69,10 +70,10 @@ public class FileDialog {
 		File selectedFile = null;
 		initSaveAllDialog();
 
-		retrieveSaveDialogDir(fcSaveAll);
+        extractedFileDialog.retrieveSaveDialogDir(fcSaveAll);
 		fcSaveAll.setSelectedFile(new File(recommendedFileName));
 		int returnVal = fcSaveAll.showSaveDialog(parent);
-		saveSaveDialogDir(fcSaveAll);
+        extractedFileDialog.saveSaveDialogDir(fcSaveAll);
 
 		if (returnVal == JFileChooser.APPROVE_OPTION) {
 			selectedFile = fcSaveAll.getSelectedFile();
@@ -83,21 +84,21 @@ public class FileDialog {
 	public synchronized void initOpenDialog() {
 		if (fcOpen == null) {
 			fcOpen = createFileChooser("*.jar", "*.zip", "*.class");
-			retrieveOpenDialogDir(fcOpen);
+            extractedFileDialog.retrieveOpenDialogDir(fcOpen);
 		}
 	}
 
 	public synchronized void initSaveDialog() {
 		if (fcSave == null) {
 			fcSave = createFileChooser("*.txt", "*.java");
-			retrieveSaveDialogDir(fcSave);
+            extractedFileDialog.retrieveSaveDialogDir(fcSave);
 		}
 	}
 
 	public synchronized void initSaveAllDialog() {
 		if (fcSaveAll == null) {
 			fcSaveAll = createFileChooser("*.jar", "*.zip");
-			retrieveSaveDialogDir(fcSaveAll);
+            extractedFileDialog.retrieveSaveDialogDir(fcSaveAll);
 		}
 	}
 
@@ -131,53 +132,4 @@ public class FileDialog {
 		}
 	}
 
-	private void retrieveOpenDialogDir(JFileChooser fc) {
-		try {
-			String currentDirStr = luytenPrefs.getFileOpenCurrentDirectory();
-			if (currentDirStr != null && currentDirStr.trim().length() > 0) {
-				File currentDir = new File(currentDirStr);
-				if (currentDir.exists() && currentDir.isDirectory()) {
-					fc.setCurrentDirectory(currentDir);
-				}
-			}
-		} catch (Exception e) {
-			Luyten.showExceptionDialog("Exception!", e);
-		}
-	}
-
-	private void saveOpenDialogDir(JFileChooser fc) {
-		try {
-			File currentDir = fc.getCurrentDirectory();
-			if (currentDir != null && currentDir.exists() && currentDir.isDirectory()) {
-				luytenPrefs.setFileOpenCurrentDirectory(currentDir.getAbsolutePath());
-			}
-		} catch (Exception e) {
-			Luyten.showExceptionDialog("Exception!", e);
-		}
-	}
-
-	private void retrieveSaveDialogDir(JFileChooser fc) {
-		try {
-			String currentDirStr = luytenPrefs.getFileSaveCurrentDirectory();
-			if (currentDirStr != null && currentDirStr.trim().length() > 0) {
-				File currentDir = new File(currentDirStr);
-				if (currentDir.exists() && currentDir.isDirectory()) {
-					fc.setCurrentDirectory(currentDir);
-				}
-			}
-		} catch (Exception e) {
-			Luyten.showExceptionDialog("Exception!", e);
-		}
-	}
-
-	private void saveSaveDialogDir(JFileChooser fc) {
-		try {
-			File currentDir = fc.getCurrentDirectory();
-			if (currentDir != null && currentDir.exists() && currentDir.isDirectory()) {
-				luytenPrefs.setFileSaveCurrentDirectory(currentDir.getAbsolutePath());
-			}
-		} catch (Exception e) {
-			Luyten.showExceptionDialog("Exception!", e);
-		}
-	}
 }

--- a/src/us/deathmarine/luyten/FileDialog.java
+++ b/src/us/deathmarine/luyten/FileDialog.java
@@ -9,7 +9,7 @@ import javax.swing.filechooser.FileFilter;
  * FileChoosers for Open and Save
  */
 public class FileDialog {
-    private final ExtractedFileDialog extractedFileDialog;
+    private final DirPreferences dirPreferences;
     private ConfigSaver configSaver;
     private Component parent;
 	private JFileChooser fcOpen;
@@ -20,7 +20,7 @@ public class FileDialog {
 		this.parent = parent;
 		configSaver = ConfigSaver.getLoadedInstance();
         LuytenPreferences luytenPrefs = configSaver.getLuytenPreferences();
-        extractedFileDialog = new ExtractedFileDialog(luytenPrefs);
+        dirPreferences = new DirPreferences(luytenPrefs);
 
         new Thread() {
 			public void run() {
@@ -41,9 +41,9 @@ public class FileDialog {
 		File selectedFile = null;
 		initOpenDialog();
 
-        extractedFileDialog.retrieveOpenDialogDir(fcOpen);
+        dirPreferences.retrieveOpenDialogDir(fcOpen);
 		int returnVal = fcOpen.showOpenDialog(parent);
-        extractedFileDialog.saveOpenDialogDir(fcOpen);
+        dirPreferences.saveOpenDialogDir(fcOpen);
 
 		if (returnVal == JFileChooser.APPROVE_OPTION) {
 			selectedFile = fcOpen.getSelectedFile();
@@ -55,10 +55,10 @@ public class FileDialog {
 		File selectedFile = null;
 		initSaveDialog();
 
-        extractedFileDialog.retrieveSaveDialogDir(fcSave);
+        dirPreferences.retrieveSaveDialogDir(fcSave);
 		fcSave.setSelectedFile(new File(recommendedFileName));
 		int returnVal = fcSave.showSaveDialog(parent);
-        extractedFileDialog.saveSaveDialogDir(fcSave);
+        dirPreferences.saveSaveDialogDir(fcSave);
 
 		if (returnVal == JFileChooser.APPROVE_OPTION) {
 			selectedFile = fcSave.getSelectedFile();
@@ -70,10 +70,10 @@ public class FileDialog {
 		File selectedFile = null;
 		initSaveAllDialog();
 
-        extractedFileDialog.retrieveSaveDialogDir(fcSaveAll);
+        dirPreferences.retrieveSaveDialogDir(fcSaveAll);
 		fcSaveAll.setSelectedFile(new File(recommendedFileName));
 		int returnVal = fcSaveAll.showSaveDialog(parent);
-        extractedFileDialog.saveSaveDialogDir(fcSaveAll);
+        dirPreferences.saveSaveDialogDir(fcSaveAll);
 
 		if (returnVal == JFileChooser.APPROVE_OPTION) {
 			selectedFile = fcSaveAll.getSelectedFile();
@@ -84,21 +84,21 @@ public class FileDialog {
 	public synchronized void initOpenDialog() {
 		if (fcOpen == null) {
 			fcOpen = createFileChooser("*.jar", "*.zip", "*.class");
-            extractedFileDialog.retrieveOpenDialogDir(fcOpen);
+            dirPreferences.retrieveOpenDialogDir(fcOpen);
 		}
 	}
 
 	public synchronized void initSaveDialog() {
 		if (fcSave == null) {
 			fcSave = createFileChooser("*.txt", "*.java");
-            extractedFileDialog.retrieveSaveDialogDir(fcSave);
+            dirPreferences.retrieveSaveDialogDir(fcSave);
 		}
 	}
 
 	public synchronized void initSaveAllDialog() {
 		if (fcSaveAll == null) {
 			fcSaveAll = createFileChooser("*.jar", "*.zip");
-            extractedFileDialog.retrieveSaveDialogDir(fcSaveAll);
+            dirPreferences.retrieveSaveDialogDir(fcSaveAll);
 		}
 	}
 


### PR DESCRIPTION
`FileDialog` handles file dialog. Among its responsibilities, it loads and saves the default directory for loading.

I have refactored out this load&save logic to a helper object, as it simplified the logic in `FileDialog` and left it to manage the dialog in a higher level.

For more information about "Extract Class" refactoring. see https://refactoring.guru/extract-class

We created this refactoring using automatic tools. See our website
www.refactormachine.com

Performed extract class operation for `FileDialog`.
**Extracted fields:** luytenPrefs
**Extracted Methods:** `retrieveOpenDialogDir()`, `saveOpenDialogDir()`, `retrieveSaveDialogDir()`, `saveSaveDialogDir()` .
