### PR TITLE
New feature to handle WAR files as input

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
 			<version>0.5.27</version>
 		</dependency>
 		-->
+		<dependency>
+			<groupId>org.apache.ant</groupId>
+			<artifactId>ant-compress</artifactId>
+			<version>LATEST</version>
+		</dependency>
 	</dependencies>
 	<repositories>
 		<repository>
@@ -95,8 +100,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -166,8 +171,8 @@
 							</classPath>
 							<icon>luyten.ico</icon>
 							<jre>
-								<minVersion>1.7.0</minVersion>
-								<maxVersion>1.8.0</maxVersion>
+								<minVersion>1.8.0</minVersion>
+								<!--  <maxVersion>1.8.0</maxVersion> -->
 								<initialHeapSize>128</initialHeapSize>
 								<maxHeapSize>1024</maxHeapSize>
 							</jre>

--- a/src/us/deathmarine/luyten/FileDialog.java
+++ b/src/us/deathmarine/luyten/FileDialog.java
@@ -82,7 +82,7 @@ public class FileDialog {
 
 	public synchronized void initOpenDialog() {
 		if (fcOpen == null) {
-			fcOpen = createFileChooser("*.jar", "*.zip", "*.class");
+			fcOpen = createFileChooser("*.jar", "*.zip", "*.war", "*.class");
 			retrieveOpenDialogDir(fcOpen);
 		}
 	}

--- a/src/us/deathmarine/luyten/FileSaver.java
+++ b/src/us/deathmarine/luyten/FileSaver.java
@@ -108,7 +108,9 @@ public class FileSaver {
 					System.out.println("[SaveAll]: " + inFile.getName() + " -> " + outFile.getName());
 					String inFileName = inFile.getName().toLowerCase();
 
-					if (inFileName.endsWith(".jar") || inFileName.endsWith(".zip")) {
+					if (inFileName.endsWith(".jar")
+							|| inFileName.endsWith(".zip")
+							|| inFileName.endsWith(".war")) {
 						doSaveJarDecompiled(inFile, outFile);
 					} else if (inFileName.endsWith(".class")) {
 						doSaveClassDecompiled(inFile, outFile);

--- a/src/us/deathmarine/luyten/LuytenPreferences.java
+++ b/src/us/deathmarine/luyten/LuytenPreferences.java
@@ -20,6 +20,9 @@ public class LuytenPreferences {
 	private boolean isFilterOutInnerClassEntries = true;
 	private boolean isSingleClickOpenEnabled = true;
 	private boolean isExitByEscEnabled = false;
+	private boolean isFollowEmbeddedJarFile = true;
+	private boolean isPrepareWarFile = false;
+
 
 	public String getThemeXml() {
 		return themeXml;
@@ -77,6 +80,41 @@ public class LuytenPreferences {
 		this.isExitByEscEnabled = isExitByEscEnabled;
 	}
 
+	/*
+	 * Maybe this makes sense for WAR files only (located in WEB-INF/lib)
+	 * If opened input file is a JAR / ZIP or WAR file and the package contains a JAR file inside
+	 * control what happens with that embedded JAR file
+	 * should be unprocessed and displayed only or opened by accessing them
+	 * isFollowEmbeddedJarFile:
+	 * true  = by selecting the JAR file, it is opened as new input file
+	 * false = do not follow that embedded JAR file, just display in the tree as JAR file and notify user as binary resource file
+	 */
+	public boolean isFollowEmbeddedJarFile() {
+		return isFollowEmbeddedJarFile;
+	}
+
+	public void setFollowEmbeddedJarFile(boolean isFollowEmbeddedJarFile) {
+		this.isFollowEmbeddedJarFile = isFollowEmbeddedJarFile;
+	}
+
+	/*
+	 * For WAR files only: They contain embedded JAR files (located in WEB-INF/lib) which has to be decompiled as well
+	 * This is great to get an overall view to the source code and call hierarchy. Turn the blackbox into a whitebox ;-)
+	 * isPrepareWarFile:
+	 * true = unzip the WAR file and _all_ embedded JAR files with its package file name into temporary directory and create an overall ZIP file from this temporary directory
+	 *        At the end this new zip file is opened and will show _all_ CLASS Files at once
+	 * false  = do not pre-process the WAR file, just display embedded JAR files in the tree as JAR file - in this case maybe check the option isFollowEmbeddedJarFile to go into that JAR file
+	 */
+	public boolean isPrepareWarFile() {
+		return isPrepareWarFile;
+	}
+
+	public void setPrepareWarFile(boolean isPrepareWarFile) {
+		this.isPrepareWarFile = isPrepareWarFile;
+	}
+
+	
+	
 	public int getFont_size() {
 		return font_size;
 	}

--- a/src/us/deathmarine/luyten/MainMenuBar.java
+++ b/src/us/deathmarine/luyten/MainMenuBar.java
@@ -68,6 +68,8 @@ public class MainMenuBar extends JMenuBar {
 	private JCheckBoxMenuItem filterOutInnerClassEntries;
 	private JCheckBoxMenuItem singleClickOpenEnabled;
 	private JCheckBoxMenuItem exitByEscEnabled;
+	private JCheckBoxMenuItem followEmbeddedJarFile;
+	private JCheckBoxMenuItem prepareWarFile;
 	private DecompilerSettings settings;
 	private LuytenPreferences luytenPrefs;
 
@@ -419,6 +421,27 @@ public class MainMenuBar extends JMenuBar {
 			}
 		});
 		operationMenu.add(exitByEscEnabled);
+		
+		followEmbeddedJarFile = new JCheckBoxMenuItem("Follow Embedded Jar File");
+		followEmbeddedJarFile.setSelected(luytenPrefs.isFollowEmbeddedJarFile());
+		followEmbeddedJarFile.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				luytenPrefs.setFollowEmbeddedJarFile(followEmbeddedJarFile.isSelected());
+			}
+		});
+		operationMenu.add(followEmbeddedJarFile);
+		
+		prepareWarFile = new JCheckBoxMenuItem("Prepare WAR File (extract all CLASSES from embedded JAR files)");
+		prepareWarFile.setSelected(luytenPrefs.isPrepareWarFile());
+		prepareWarFile.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				luytenPrefs.setPrepareWarFile(prepareWarFile.isSelected());
+			}
+		});
+		operationMenu.add(prepareWarFile);
+		
 	}
 
 	private void buildSettingsMenu(JMenu settingsMenu, ConfigSaver configSaver) {

--- a/src/us/deathmarine/luyten/MainWindow.java
+++ b/src/us/deathmarine/luyten/MainWindow.java
@@ -89,7 +89,7 @@ public class MainWindow extends JFrame {
 
 		JSplitPane spt = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, panel1, panel2) {
 			private static final long serialVersionUID = 2189946972124687305L;
-			private final int location = 400;
+			private final int location = 800;
 
 			{
 				setDividerLocation(location);
@@ -126,7 +126,8 @@ public class MainWindow extends JFrame {
 		this.setExitOnEscWhenEnabled(model);
 
 		if (fileFromCommandLine == null || fileFromCommandLine.getName().toLowerCase().endsWith(".jar")
-				|| fileFromCommandLine.getName().toLowerCase().endsWith(".zip")) {
+				|| fileFromCommandLine.getName().toLowerCase().endsWith(".zip")
+				|| fileFromCommandLine.getName().toLowerCase().endsWith(".war")) {
 			model.startWarmUpThread();
 		}
 		
@@ -171,6 +172,8 @@ public class MainWindow extends JFrame {
 			fileName = fileName.replace(".class", ".java");
 		} else if (fileName.toLowerCase().endsWith(".jar")) {
 			fileName = "decompiled-" + fileName.replaceAll("\\.[jJ][aA][rR]", ".zip");
+		} else if (fileName.toLowerCase().endsWith(".war")) {
+			fileName = "decompiled-war-" + fileName.replaceAll("\\.[wW][aA][rR]", ".zip");
 		} else {
 			fileName = "saved-" + fileName;
 		}
@@ -331,6 +334,8 @@ public class MainWindow extends JFrame {
 
 	private void adjustWindowPositionBySavedState() {
 		Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+		this.setMinimumSize(new Dimension(800, 600));
+
 		if (!windowPosition.isSavedWindowPositionValid()) {
 			final Dimension center = new Dimension((int) (screenSize.width * 0.75), (int) (screenSize.height * 0.75));
 			final int x = (int) (center.width * 0.2);

--- a/src/us/deathmarine/luyten/Model.java
+++ b/src/us/deathmarine/luyten/Model.java
@@ -1,5 +1,6 @@
 package us.deathmarine.luyten;
 
+import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -16,6 +17,9 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,6 +33,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.stream.Stream;
 
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
@@ -44,6 +49,7 @@ import javax.swing.JTabbedPane;
 import javax.swing.JTree;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.TreeExpansionEvent;
@@ -53,9 +59,15 @@ import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
+
+import org.apache.ant.compress.taskdefs.Unzip;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.taskdefs.Zip;
+import org.apache.tools.ant.types.FileSet;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.Theme;
 import org.fife.ui.rtextarea.RTextScrollPane;
+
 import com.strobel.assembler.InputTypeLoader;
 import com.strobel.assembler.metadata.ITypeLoader;
 import com.strobel.assembler.metadata.JarTypeLoader;
@@ -75,7 +87,7 @@ public class Model extends JSplitPane {
 	private static final long serialVersionUID = 6896857630400910200L;
 
 	private static final long MAX_JAR_FILE_SIZE_BYTES = 1_000_000_000;
-	private static final long MAX_UNPACKED_FILE_SIZE_BYTES = 1_000_000;
+	private static final long MAX_UNPACKED_FILE_SIZE_BYTES = 200_000_000;
 
 	private static LuytenTypeLoader typeLoader = new LuytenTypeLoader();
 	public static MetadataSystem metadataSystem = new MetadataSystem(typeLoader);
@@ -83,6 +95,7 @@ public class Model extends JSplitPane {
 	private JTree tree;
 	public JTabbedPane house;
 	private File file;
+	private Path tempFileLocation;
 	private DecompilerSettings settings;
 	private DecompilationOptions decompilationOptions;
 	private Theme theme;
@@ -141,6 +154,7 @@ public class Model extends JSplitPane {
 		panel2.setBorder(BorderFactory.createTitledBorder("Structure"));
 		panel2.add(new JScrollPane(tree));
 
+		UIManager.put("TabbedPane.selected", Color.WHITE);		// highlight the currently selected tab
 		house = new JTabbedPane();
 		house.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
 		house.addChangeListener(new TabChangeListener());
@@ -315,7 +329,9 @@ public class Model extends JSplitPane {
 				}
 				path = path + name;
 
-				if (file.getName().endsWith(".jar") || file.getName().endsWith(".zip")) {
+				if (file.getName().endsWith(".jar")
+						|| file.getName().endsWith(".zip")
+						|| file.getName().endsWith(".war")) {
 					if (state == null) {
 						JarFile jfile = new JarFile(file);
 						ITypeLoader jarLoader = new JarTypeLoader(jfile);
@@ -337,6 +353,28 @@ public class Model extends JSplitPane {
 						String internalName = StringUtilities.removeRight(entryName, ".class");
 						TypeReference type = metadataSystem.lookupType(internalName);
 						extractClassToTextPane(type, name, path, null);
+					} else if (entryName.endsWith(".jar")) {
+						// A JAR file within a WAR file is selected
+						if (luytenPrefs.isFollowEmbeddedJarFile()) {
+							//Jetzt die tempFileLocation einlesen und alle JAR Dateien holen
+							if (file.getName().endsWith(".war")) {	// initial loaded file is a WAR file
+								getLabel().setText("Extract embedded JAR file " + entryName + " from " + tempFileLocation + " ...");
+								try (Stream<Path> paths = Files.walk(tempFileLocation)) {
+							        paths.filter(Files::isRegularFile)
+							                .filter(embeddedFile -> embeddedFile.toString().endsWith(entryName.substring(entryName.lastIndexOf('/') + 1)))
+							                .forEach((Path filePath) -> {
+							                	// This will open the selected JAR file from tempFileLocation
+							                	// and will close the initial opened WAR file
+							                	loadFile(filePath.toFile());
+							                });
+							    } catch (Exception e) {
+							    	Luyten.showExceptionDialog("Exception!", e);
+							    }
+							}
+						} else {
+							getLabel().setText("Binary resource: " + entryName + " / You may activate option 'Follow Embedded Jar File'");
+							Thread.sleep(5000);
+						}
 					} else {
 						getLabel().setText("Opening: " + name);
 						try (InputStream in = state.jarFile.getInputStream(entry);) {
@@ -364,7 +402,7 @@ public class Model extends JSplitPane {
 
 			getLabel().setText("Complete");
 		} catch (FileEntryNotFoundException e) {
-			getLabel().setText("File not found: " + name);
+			getLabel().setText("File not found: " + file);
 		} catch (FileIsBinaryException e) {
 			getLabel().setText("Binary resource: " + name);
 		} catch (TooLargeFileException e) {
@@ -684,19 +722,94 @@ public class Model extends JSplitPane {
 					if (file.length() > MAX_JAR_FILE_SIZE_BYTES) {
 						throw new TooLargeFileException(file.length());
 					}
-					if (file.getName().endsWith(".zip") || file.getName().endsWith(".jar")) {
+					getLabel().setText("Starting ...");
+					
+					/* 
+					 * Known limitations of processing WAR files
+					 * + The WAR file is unzipped into temp folder directory, this takes some time on bigger files 
+					 * + There is no DeleteOnExit of that temp folder directory. Do this manually by now!
+					 * + All embedded JAR files needs to be unzipped and a final ZIP file is create, this takes some times due to file system I/O
+					 */
+					if (file.getName().endsWith(".war")) {
+						tempFileLocation = Files.createTempDirectory("luyten_", new FileAttribute<?>[0]);
+						getLabel().setText("Unpacking file to temp " + tempFileLocation.getFileName() + " ...");
+						Unzip unzipper = new Unzip();
+						unzipper.setEncoding("UTF-8");
+						unzipper.setSrc(file);
+						unzipper.setDest(tempFileLocation.toFile());
+						unzipper.execute();
+						
+						if (luytenPrefs.isPrepareWarFile()) {
+							if (file.getName().endsWith(".war")) {
+								//Jetzt die tempFileLocation einlesen und alle JAR Dateien direkt entpacken
+									getLabel().setText("Processing embedded JAR files ...");
+									final List<Path> embeddedPackageFiles = new ArrayList<>();
+
+								    try (Stream<Path> paths = Files.walk(tempFileLocation)) {
+										getLabel().setText("scanning tempFileLocation for JAR files: "+tempFileLocation);
+								        paths.filter(Files::isRegularFile)
+								                .filter(file -> (file.toString().endsWith(".jar")))
+								                .forEach((Path filePath) -> {
+													getLabel().setText("adding JAR file: "+filePath);
+													embeddedPackageFiles.add(filePath);
+								                });
+								    } catch (Exception e) {
+								    	Luyten.showExceptionDialog("Exception!", e);
+								    }
+								    
+									for (Path singleJar : embeddedPackageFiles) {
+										getLabel().setText("Unpacking " + singleJar.getFileName() + " to temp " + tempFileLocation.getFileName() + " ...");
+										unzipper.setSrc(singleJar.toFile());
+										unzipper.setDest(new File(singleJar.getParent().toString()+"/"+singleJar.getFileName().toString().substring(0, singleJar.getFileName().toString().length() - 4)));
+									    try {
+									    	unzipper.execute();
+									    	singleJar.toFile().delete();
+									    } catch (Exception e) {
+									    	Luyten.showExceptionDialog("Exception!", e);
+									    }
+									}
+									
+									Project project = new Project();
+									FileSet fileSet = new FileSet();
+								    fileSet.setDir(tempFileLocation.toFile());
+								    fileSet.setProject(project);
+
+									File destTempZipFile = new File(tempFileLocation.getParent().toString()+"/"+file.getName().substring(0, file.getName().length() - 4)+".zip");
+									
+									getLabel().setText("Packing files back to ZIP file  to temp " + destTempZipFile.getName() + " ...");
+
+									Zip zipper = new Zip();
+									zipper.setProject(project);
+									zipper.setEncoding("UTF-8");
+									// do not really compress to save time in that process step
+									zipper.setCompress(false);
+									zipper.addFileset(fileSet);
+									zipper.setDestFile(destTempZipFile);
+									zipper.execute();
+									
+									file = destTempZipFile;
+								}
+						}
+					}
+					
+					if (file.getName().endsWith(".zip")
+							|| file.getName().endsWith(".jar")
+							|| file.getName().endsWith(".war")) {
 						JarFile jfile;
 						jfile = new JarFile(file);
 						getLabel().setText("Loading: " + jfile.getName());
 						bar.setVisible(true);
 
 						JarEntryFilter jarEntryFilter = new JarEntryFilter(jfile);
-						List<String> mass = null;
+						ArrayList<String> mass = new ArrayList<String>();
 						if (luytenPrefs.isFilterOutInnerClassEntries()) {
-							mass = jarEntryFilter.getEntriesWithoutInnerClasses();
+							mass.addAll(jarEntryFilter.getEntriesWithoutInnerClasses());
 						} else {
-							mass = jarEntryFilter.getAllEntriesFromJar();
+							mass.addAll(jarEntryFilter.getAllEntriesFromJar());
 						}
+						
+	                	getLabel().setText("Building tree information from "+ mass.size() +" entries ...");
+	                	Thread.sleep(1000);
 						buildTreeFromMass(mass);
 
 						if (state == null) {
@@ -705,14 +818,14 @@ public class Model extends JSplitPane {
 							state = new State(file.getCanonicalPath(), file, jfile, jarLoader);
 						}
 						open = true;
-						getLabel().setText("Complete");
+						getLabel().setText("Complete (file is a package)");
 					} else {
 						TreeNodeUserObject topNodeUserObject = new TreeNodeUserObject(getName(file.getName()));
 						final DefaultMutableTreeNode top = new DefaultMutableTreeNode(topNodeUserObject);
 						tree.setModel(new DefaultTreeModel(top));
 						settings.setTypeLoader(new InputTypeLoader());
 						open = true;
-						getLabel().setText("Complete");
+						getLabel().setText("Complete (single file)");
 
 						// open it automatically
 						new Thread() {
@@ -776,13 +889,18 @@ public class Model extends JSplitPane {
 				return o2.split("/").length - o1.split("/").length;
 			}
 		});
-		for (String pack : packs)
-			for (String m : mass)
-				if (!m.contains("META-INF") && m.contains(pack) && !m.replace(pack, "").contains("/"))
+		for (String pack : packs) {
+			for (String m : mass) {
+				if (!m.contains("META-INF") && m.contains(pack) && !m.replace(pack, "").contains("/")) {
 					sort.add(m);
-		for (String m : mass)
-			if (!m.contains("META-INF") && !m.contains("/") && !sort.contains(m))
+				}
+			}
+		}
+		for (String m : mass) {
+			if (!m.contains("META-INF") && !m.contains("/") && !sort.contains(m)) {
 				sort.add(m);
+			}
+		}
 		for (String pack : sort) {
 			LinkedList<String> list = new LinkedList<String>(Arrays.asList(pack.split("/")));
 			loadNodesByNames(top, list);
@@ -820,15 +938,15 @@ public class Model extends JSplitPane {
 				packages.put(packagePath, new TreeSet<String>(sortByFileExtensionsComparator));
 			}
 			packages.get(packagePath).add(packageEntry);
-			if (!entry.startsWith("META-INF") && packageRoot.trim().length() > 0
+			if (!entry.startsWith("META-INF") && !entry.startsWith("WEB-INF") && packageRoot.trim().length() > 0
 					&& entry.matches(".*\\.(class|java|prop|properties)$")) {
 				classContainingPackageRoots.add(packageRoot);
 			}
 		}
 
-		// META-INF comes first -> not flat
+		// META-INF and WEB-INF or included JAR files comes first -> not flat
 		for (String packagePath : packages.keySet()) {
-			if (packagePath.startsWith("META-INF")) {
+			if (packagePath.startsWith("META-INF") || packagePath.startsWith("WEB-INF") || packagePath.endsWith(".jar")) {
 				List<String> packagePathElements = Arrays.asList(packagePath.split("/"));
 				for (String entry : packages.get(packagePath)) {
 					ArrayList<String> list = new ArrayList<>(packagePathElements);
@@ -837,6 +955,7 @@ public class Model extends JSplitPane {
 				}
 			}
 		}
+		
 
 		// real packages: path starts with a classContainingPackageRoot -> flat
 		for (String packagePath : packages.keySet()) {
@@ -854,7 +973,7 @@ public class Model extends JSplitPane {
 		// the rest, not real packages but directories -> not flat
 		for (String packagePath : packages.keySet()) {
 			String packageRoot = packagePath.replaceAll("/.*$", "");
-			if (!classContainingPackageRoots.contains(packageRoot) && !packagePath.startsWith("META-INF")
+			if (!classContainingPackageRoots.contains(packageRoot) && (!packagePath.startsWith("META-INF") || !packagePath.startsWith("WEB-INF"))
 					&& packagePath.length() > 0) {
 				List<String> packagePathElements = Arrays.asList(packagePath.split("/"));
 				for (String entry : packages.get(packagePath)) {


### PR DESCRIPTION
Known limitations of processing WAR files
* The WAR file is unzipped into temp folder directory, this takes some time on bigger files
* There is no DeleteOnExit of that temp folder directory. Do this manually by now!
* All embedded JAR files needs to be unzipped and a final ZIP file is create, this takes some times due to file system I/O