### PR TITLE
procyon update to 0.5.36 for its issue 336

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,22 +18,22 @@
 		<dependency> 
 			<groupId>org.bitbucket.mstrobel</groupId> 
 			<artifactId>procyon-core</artifactId> 
-			<version>0.5.35</version> 
+			<version>0.5.36</version> 
 		</dependency> 
 		<dependency> 
 			<groupId>org.bitbucket.mstrobel</groupId> 
 			<artifactId>procyon-expressions</artifactId> 
-			<version>0.5.35</version> 
+			<version>0.5.36</version> 
 		</dependency> 
 		<dependency> 
 			<groupId>org.bitbucket.mstrobel</groupId> 
 			<artifactId>procyon-reflection</artifactId> 
-			<version>0.5.35</version> 
+			<version>0.5.36</version> 
 		</dependency> 
 		<dependency> 
 			<groupId>org.bitbucket.mstrobel</groupId> 
 			<artifactId>procyon-compilertools</artifactId> 
-			<version>0.5.35</version> 
+			<version>0.5.36</version> 
 		</dependency> 
 		<!--
 		<dependency>


### PR DESCRIPTION
Long running [procyon issue 336](https://bitbucket.org/mstrobel/procyon/issues/336/) for exception on ```StringConcatFactory.makeConcatWithConstant``` was fixed and released now as new version 0.5.36.
Rebuilding and running Luyten with openJDK 12.0.2 will decompile now such classes without any error.
Running with old Java 8 I still get the exception.

This PR will stop all those issues [counting 15 today](https://github.com/deathmarine/Luyten/search?q=StringConcatFactory&type=Issues) complaining about the same issue again and again