### PR TITLE
Fix duplicate file names replacing tabs (Fixes #20)

### DIFF
--- a/src/us/deathmarine/luyten/Model.java
+++ b/src/us/deathmarine/luyten/Model.java
@@ -1,5 +1,6 @@
 package us.deathmarine.luyten;
 
+import java.awt.Component;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -198,15 +199,25 @@ public class Model extends JSplitPane {
 				try {
 					final String title = open.name;
 					RTextScrollPane rTextScrollPane = open.scrollPane;
-					if (house.indexOfTab(title) < 0) {
+					int index = house.indexOfTab(title);
+					if (index > -1 && house.getTabComponentAt(index) != open.scrollPane) {
+						index = -1;
+						for (int i = 0; i < house.getTabCount(); i++) {
+							if (house.getComponentAt(i) == open.scrollPane) {
+								index = i;
+								break;
+							}
+						}
+					}
+					if (index < 0) {
 						house.addTab(title, rTextScrollPane);
-						house.setSelectedIndex(house.indexOfTab(title));
-						int index = house.indexOfTab(title);
+						index = house.indexOfComponent(rTextScrollPane);
+						house.setSelectedIndex(index);
 						Tab ct = new Tab(title);
 						ct.getButton().addMouseListener(new CloseTab(title));
 						house.setTabComponentAt(index, ct);
 					} else {
-						house.setSelectedIndex(house.indexOfTab(title));
+						house.setSelectedIndex(index);
 					}
 					open.onAddedToScreen();
 				} catch (Exception e) {
@@ -384,13 +395,12 @@ public class Model extends JSplitPane {
 		}
 		OpenFile sameTitledOpen = null;
 		for (OpenFile nextOpen : hmap) {
-			if (tabTitle.equals(nextOpen.name)) {
+			if (tabTitle.equals(nextOpen.name) && path.equals(nextOpen.path) && type.equals(nextOpen.getType())) {
 				sameTitledOpen = nextOpen;
 				break;
 			}
 		}
-		if (sameTitledOpen != null && path.equals(sameTitledOpen.path) && type.equals(sameTitledOpen.getType())
-				&& sameTitledOpen.isContentValid()) {
+		if (sameTitledOpen != null && sameTitledOpen.isContentValid()) {
 			sameTitledOpen.setInitialNavigationLink(navigatonLink);
 			addOrSwitchToTab(sameTitledOpen);
 			return;
@@ -430,12 +440,12 @@ public class Model extends JSplitPane {
 		}
 		OpenFile sameTitledOpen = null;
 		for (OpenFile nextOpen : hmap) {
-			if (tabTitle.equals(nextOpen.name)) {
+			if (tabTitle.equals(nextOpen.name) && path.equals(nextOpen.path)) {
 				sameTitledOpen = nextOpen;
 				break;
 			}
 		}
-		if (sameTitledOpen != null && path.equals(sameTitledOpen.path)) {
+		if (sameTitledOpen != null) {
 			addOrSwitchToTab(sameTitledOpen);
 			return;
 		}

--- a/src/us/deathmarine/luyten/OpenFile.java
+++ b/src/us/deathmarine/luyten/OpenFile.java
@@ -820,7 +820,7 @@ public class OpenFile implements SyntaxConstants {
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((path == null) ? 0 : path.hashCode());
 		return result;
 	}
 
@@ -833,10 +833,10 @@ public class OpenFile implements SyntaxConstants {
 		if (getClass() != obj.getClass())
 			return false;
 		OpenFile other = (OpenFile) obj;
-		if (name == null) {
-			if (other.name != null)
+		if (path == null) {
+			if (other.path != null)
 				return false;
-		} else if (!name.equals(other.name))
+		} else if (!path.equals(other.path))
 			return false;
 		return true;
 	}


### PR DESCRIPTION
When opening a file which has the same name as another opened file the tab would be replaced with the content of the new file instead of opening a new tab. This PR fixed that issue.

This is done by comparing the paths instead of the file names when calculating if a new tab should be opened and also checking if component at the found index is actually the one we want to open before switching to it.