### PR TITLE
Change Maven address to HTTPS.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>us.deathmarine</groupId>
 	<artifactId>luyten</artifactId>
@@ -50,7 +49,7 @@
 			</snapshots>
 			<id>central</id>
 			<name>Central Repository</name>
-			<url>http://repo.maven.apache.org/maven2</url>
+			<url>https://repo.maven.apache.org/maven2</url>
 		</repository>
 	</repositories>
 	<build>


### PR DESCRIPTION
Fixes #238

Since about January 15, a lot of Maven repositories no longer support HTTP. This requires us to use the HTTPS address, as an automatic redirect is no longer offered.