### PR TITLE
Avoid launching Luyten.app with incompatible JVM on macOS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
 											mainclass="${project.groupId}.${project.artifactId}.LuytenOsx"
 											version="${project.version}" copyright="2015"
 											icon="${project.build.sourceDirectory}/resources/luyten.icns"
-											jvmversion="1.7+" screenmenu="true" 
+											jvmversion="1.7;1.8*" screenmenu="true" 
 											antialiasedgraphics="true" highresolutioncapable="true" >
 									<documenttype name="Class File" extensions="class" role="Viewer" />
 									<documenttype name="Java File" extensions="java" role="Viewer" />


### PR DESCRIPTION
Restrict the compatible jvm version to 1.7 and 1.8
See https://github.com/tofi86/universalJavaApplicationStub/issues/51